### PR TITLE
Fix docs building

### DIFF
--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -297,7 +297,7 @@ You're likely using an unsupported partition type:
 
 **Solution**: Use `StaticPartitionsDefinition` with explicit partition keys, or use Dagster schedules for time-based execution.
 
-See [Partitions documentation](guide.md#kedro-datasets-for-dagster-partitioning) for examples.
+See [Partitions documentation](guide.md#integrating-dagster-partitions) for examples.
 
 ---
 

--- a/docs/pages/intro.md
+++ b/docs/pages/intro.md
@@ -67,7 +67,7 @@ Kedro and Dagster logging is unified to provide a consistent logging experience 
 
 ### (Experimental) Dagster partitions support
 
-Enable key-based [Dagster partitions](https://docs.dagster.io/guides/build/partitions-and-backfills) to backfill, schedule, and process incremental slices of your pipelines. Currently supports `StaticPartitionsDefinition` with `StaticPartitionMapping` or `IdentityPartitionMapping`. See the [user guide](guide.md#kedro-datasets-for-dagster-partitioning) for details on supported features and alternatives for time-based partitioning.
+Enable key-based [Dagster partitions](https://docs.dagster.io/guides/build/partitions-and-backfills) to backfill, schedule, and process incremental slices of your pipelines. Currently supports `StaticPartitionsDefinition` with `StaticPartitionMapping` or `IdentityPartitionMapping`. See the [user guide](guide.md#integrating-dagster-partitions) for details on supported features and alternatives for time-based partitioning.
 
 ## Limitations and considerations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,8 +113,4 @@ plugins:
               returns_named_value: false
           paths: [src]
 
-extra:
-  version:
-    provider: mike
-
 copyright: Copyright &copy; 2024 - 2025 Guillaume Tauzin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,13 +55,13 @@ dev = [
   { include-group = "fix" },
 ]
 docs = [
-  "mkdocs-material==9.5",
-  "mkdocs-git-revision-date-localized-plugin==1.3",
-  "mkdocstrings==0.27",
-  "mkdocstrings-python==1.16",
-  "mkdocs-glightbox==0.4",
-  "pymdown-extensions==10.14",
-  "mike==2.1",
+  "mkdocs-material==9.7",
+  "mkdocs-git-revision-date-localized-plugin==1.5",
+  "mkdocstrings==1.0",
+  "mkdocstrings-python==2.0",
+  "mkdocs-glightbox==0.5",
+  "pymdown-extensions==10.17",
+  "black==25.11",
 ]
 fix = [
   "pre-commit-uv>=4.1",


### PR DESCRIPTION
## Description
Following the removal of `uv.lock`, the docs were no longer building.

## Development notes
- Pinned docs dependencies

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
