### PR TITLE
feat: map Kedro namespaces to hierarchical Dagster asset groups

### DIFF
--- a/docs/pages/explanation/architecture.md
+++ b/docs/pages/explanation/architecture.md
@@ -37,7 +37,7 @@ Kedro datasets become three kinds of Dagster objects:
 - **Assets**: Output datasets are defined as Dagster assets.
 - **IO Managers**: Each dataset gets a dedicated IO manager wrapping its `save` and `load` methods.
 
-A Kedro dataset's `metadata` parameter is propagated to the Dagster asset. For example, `description` appears in the Dagster UI, and `group_name` overrides the default group inferred from the node's pipeline.
+A Kedro dataset's `metadata` parameter is propagated to the Dagster asset. For example, `description` appears in the Dagster UI, and `group_name` overrides the default group derived from the node's namespace (see [Asset groups](#asset-groups)).
 
 See [`CatalogTranslator`](../api/generated/kedro_dagster.catalog.CatalogTranslator.md).
 
@@ -82,6 +82,21 @@ Dagster enforces that asset, op, and job names match `^[A-Za-z0-9_]+$`. Kedro-Da
 - **Nodes**: Dots are replaced with double underscores. If the result still contains disallowed characters, the name is replaced with a stable hash placeholder (`unnamed_node_<md5>`).
 
 These rules are implemented in `src/kedro_dagster/utils.py` by `format_dataset_name`, `format_node_name`, and `unformat_asset_name`.
+
+## Asset groups
+
+Each asset is assigned to a Dagster **group** derived from its Kedro **namespace**:
+
+- **Namespaced nodes** group by their namespace. A node named `marketing.ads.train_model` produces assets in the group `marketing/ads`.
+- **Un-namespaced nodes** group by the name of the pipeline they belong to.
+- A dataset can override its group with `group_name` in its catalog `metadata`.
+
+Because Kedro pipelines already map to Dagster **jobs**, the pipeline name is *not* folded into the group — the namespace alone defines the group, which keeps groups aligned with your modular-pipeline structure and avoids redundant names like `data_science__data_science`.
+
+Namespaces are hierarchical: on Dagster ≥ 1.13.9 the namespace separator renders as `/`, so `marketing.ads` becomes the nested group `marketing/ads`. These nested groups render as a tree in the asset graph and can be selected with wildcards, e.g. `group:"marketing/*"`. On older Dagster, the namespace falls back to a flat `__`-joined group (`marketing__ads`). A `group_name` override may also use `/`; it degrades to `__` (with a warning) on older Dagster rather than failing. The capability is detected once via `SUPPORTS_HIERARCHICAL_GROUPS` and applied by `_get_node_group_name` / `_normalize_group_name` in `src/kedro_dagster/utils.py`.
+
+!!! warning "Group names changed in this release"
+    Namespaced assets previously used a flat `namespace__pipeline` group (e.g. `marketing__ads__data_science`). They now group by namespace alone, rendered hierarchically on Dagster ≥ 1.13.9 (e.g. `marketing/ads`). If you reference a group by its literal string in an asset selection, schedule, or sensor, update it to the new name.
 
 ## See also
 

--- a/src/kedro_dagster/constants.py
+++ b/src/kedro_dagster/constants.py
@@ -5,6 +5,9 @@ import re
 KEDRO_DAGSTER_SEPARATOR = "__"
 """Separator used to convert dotted Kedro dataset names into Dagster-safe identifiers."""
 
+DAGSTER_GROUP_SEPARATOR = "/"
+"""Separator for hierarchical Dagster asset group names (supported since Dagster 1.13.9)."""
+
 DAGSTER_ALLOWED_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
 """Regex that matches valid Dagster asset/resource names."""
 

--- a/src/kedro_dagster/nodes.py
+++ b/src/kedro_dagster/nodes.py
@@ -23,8 +23,9 @@ from pydantic import BaseModel, ConfigDict
 from kedro_dagster.constants import NOTHING_OUTPUT
 from kedro_dagster.utils import (
     _create_pydantic_model_from_dict,
-    _get_node_pipeline_name,
+    _get_node_group_name,
     _is_param_name,
+    _normalize_group_override,
     format_dataset_name,
     format_node_name,
     get_asset_key_from_dataset_name,
@@ -269,7 +270,7 @@ class NodeTranslator:
             Also calls this helper for op output definitions.
         """
         metadata, description = None, None
-        group_name = _get_node_pipeline_name(node)
+        group_name = _get_node_group_name(node)
         io_manager_key = "io_manager"
 
         if asset_name in self.asset_names:
@@ -277,7 +278,9 @@ class NodeTranslator:
             if dataset is not None:
                 metadata = getattr(dataset, "metadata", None) or {}
                 description = metadata.pop("description", "")
-                group_name = metadata.pop("group_name", group_name)
+                raw_group_name = metadata.pop("group_name", None)
+                if raw_group_name is not None:
+                    group_name = _normalize_group_override(raw_group_name)
                 if not isinstance(dataset, MemoryDataset):
                     candidate_key = f"{self._env}__{asset_name}_io_manager"
                     if candidate_key in self._named_resources:
@@ -734,11 +737,13 @@ class NodeTranslator:
                 if not isinstance(dataset, MemoryDataset):
                     io_manager_key = f"{self._env}__{external_asset_name}_io_manager"
 
-                group_name = metadata.pop("group_name", None)
-                if group_name is None:
+                raw_group_name = metadata.pop("group_name", None)
+                if raw_group_name is not None:
+                    group_name = _normalize_group_override(raw_group_name)
+                else:
                     # All pipeline inputs are not necessarily external. A partition that is an input of a node
                     # along with a DagsterNothingDataset is most likely part of the pipeline itself and its
-                    # group name should match that of the node's pipeline.
+                    # group name should match that of the node's group.
                     # Note that this is a best-effort attempt and may not cover all cases (e.g. same node part
                     # of multiple pipelines).
                     group_name = "external"
@@ -747,7 +752,7 @@ class NodeTranslator:
                             if external_dataset_name in pipeline_node.inputs and any(
                                 is_nothing_asset_name(self._catalog, ds) for ds in pipeline_node.inputs
                             ):
-                                group_name = _get_node_pipeline_name(pipeline_node)
+                                group_name = _get_node_group_name(pipeline_node)
                                 break
 
                 partitions_def = None

--- a/src/kedro_dagster/utils.py
+++ b/src/kedro_dagster/utils.py
@@ -12,7 +12,7 @@ import dagster as dg
 from jinja2 import Environment, FileSystemLoader
 from pydantic import create_model
 
-from kedro_dagster.constants import DAGSTER_ALLOWED_PATTERN, KEDRO_DAGSTER_SEPARATOR
+from kedro_dagster.constants import DAGSTER_ALLOWED_PATTERN, DAGSTER_GROUP_SEPARATOR, KEDRO_DAGSTER_SEPARATOR
 from kedro_dagster.datasets import DagsterNothingDataset
 
 try:
@@ -55,6 +55,14 @@ def _get_version(package: str) -> tuple[int, int, int]:
 # Compute and expose module-level constants for importers.
 KEDRO_VERSION = _get_version("kedro")
 DAGSTER_VERSION = _get_version("dagster")
+
+SUPPORTS_HIERARCHICAL_GROUPS = DAGSTER_VERSION >= (1, 13, 9)
+"""Whether the installed Dagster renders ``/``-separated hierarchical asset groups (>= 1.13.9).
+
+When ``True``, namespace segments are joined with :data:`~kedro_dagster.constants.DAGSTER_GROUP_SEPARATOR`
+(``/``) to form nested groups; otherwise they fall back to
+:data:`~kedro_dagster.constants.KEDRO_DAGSTER_SEPARATOR` (``__``).
+"""
 
 
 @dataclass
@@ -595,8 +603,84 @@ def _is_param_name(dataset_name: str) -> bool:
     return dataset_name.startswith("params:") or dataset_name == "parameters"
 
 
-def _get_node_pipeline_name(node: "Node") -> str:
-    """Return the name of the pipeline that a node belongs to.
+def _sanitize_group_segment(segment: str) -> str:
+    """Make a single asset-group path segment valid under Dagster's naming rules.
+
+    Each segment of a group name must match ``[A-Za-z0-9_]+``; any other
+    character (including a stray ``.``) is replaced with
+    :data:`~kedro_dagster.constants.KEDRO_DAGSTER_SEPARATOR` (``__``), mirroring
+    :func:`format_node_name`.
+
+    Parameters
+    ----------
+    segment : str
+        A single group path segment.
+
+    Returns
+    -------
+    str
+        Sanitized segment.
+    """
+    return re.sub(r"[^A-Za-z0-9_]", KEDRO_DAGSTER_SEPARATOR, segment)
+
+
+def _normalize_group_name(segments: list[str]) -> str:
+    """Join namespace segments into a Dagster asset group name.
+
+    Each segment is sanitized to ``[A-Za-z0-9_]`` and empty segments are
+    dropped. Segments are joined with ``/`` when the installed Dagster supports
+    hierarchical group names (>= 1.13.9, see :data:`SUPPORTS_HIERARCHICAL_GROUPS`)
+    and with ``__`` otherwise.
+
+    Parameters
+    ----------
+    segments : list[str]
+        Ordered group path segments (e.g. ``["marketing", "ads"]``).
+
+    Returns
+    -------
+    str
+        A valid Dagster group name (e.g. ``"marketing/ads"`` or ``"marketing__ads"``).
+    """
+    separator = DAGSTER_GROUP_SEPARATOR if SUPPORTS_HIERARCHICAL_GROUPS else KEDRO_DAGSTER_SEPARATOR
+    return separator.join(_sanitize_group_segment(segment) for segment in segments if segment)
+
+
+def _normalize_group_override(raw_group_name: str) -> str:
+    """Normalize a catalog ``metadata['group_name']`` override into a valid group name.
+
+    The override is split on ``/`` (the user's hierarchy marker) and re-joined
+    with the version-appropriate separator. If it uses ``/`` on a Dagster that
+    does not support hierarchical groups, it degrades to ``__`` with a warning
+    rather than raising ``DagsterInvalidDefinitionError``.
+
+    Parameters
+    ----------
+    raw_group_name : str
+        Raw override string from the catalog metadata.
+
+    Returns
+    -------
+    str
+        Normalized group name.
+    """
+    segments = raw_group_name.split(DAGSTER_GROUP_SEPARATOR)
+    if len(segments) > 1 and not SUPPORTS_HIERARCHICAL_GROUPS:
+        LOGGER.warning(
+            f"Asset group override `{raw_group_name}` uses hierarchical `/` separators, which require "
+            f"Dagster >= 1.13.9. Falling back to a `{KEDRO_DAGSTER_SEPARATOR}`-separated group name."
+        )
+    return _normalize_group_name(segments)
+
+
+def _get_node_group_name(node: "Node") -> str:
+    """Return the Dagster asset group name for a Kedro node.
+
+    The group is derived from the node's Kedro **namespace** (the dotted prefix
+    of its name), rendered hierarchically (``marketing.ads`` -> ``marketing/ads``)
+    when Dagster supports it. A node without a namespace falls back to the name of
+    the pipeline it belongs to. Pipeline membership itself is expressed by the
+    Dagster job, so the pipeline name is not folded into a namespaced node's group.
 
     Parameters
     ----------
@@ -606,14 +690,14 @@ def _get_node_pipeline_name(node: "Node") -> str:
     Returns
     -------
     str
-        Name of the pipeline the node belongs to.
+        Asset group name for the node's outputs.
 
     See Also
     --------
-    `kedro_dagster.utils.format_node_name` :
-        Formats node names for Dagster compatibility.
+    `kedro_dagster.utils._normalize_group_name` :
+        Joins namespace segments with the version-appropriate separator.
     `kedro_dagster.nodes.NodeTranslator` :
-        Uses pipeline names when building Dagster assets.
+        Uses group names when building Dagster assets.
     """
     from kedro.framework.project import find_pipelines
 
@@ -621,8 +705,7 @@ def _get_node_pipeline_name(node: "Node") -> str:
         pipelines: dict[str, Pipeline] = find_pipelines()
     except Exception:
         LOGGER.warning(
-            f"Node `{node.name}` could not be matched to a pipeline. "
-            "Assigning '__none__' as its corresponding pipeline name."
+            f"Node `{node.name}` could not be matched to a pipeline. Assigning '__none__' as its asset group name."
         )
         return "__none__"
 
@@ -631,13 +714,11 @@ def _get_node_pipeline_name(node: "Node") -> str:
             for pipeline_node in pipeline.nodes:
                 if node.name == pipeline_node.name:
                     if "." in node.name:
-                        namespace = format_node_name(".".join(node.name.split(".")[:-1]))
-                        return f"{namespace}__{pipeline_name}"
+                        # Namespaced node: group by the namespace hierarchy, not the pipeline.
+                        return _normalize_group_name(node.name.split(".")[:-1])
                     return pipeline_name
 
-    LOGGER.warning(
-        f"Node `{node.name}` is not part of any pipelines. Assigning '__none__' as its corresponding pipeline name."
-    )
+    LOGGER.warning(f"Node `{node.name}` is not part of any pipelines. Assigning '__none__' as its asset group name.")
 
     return "__none__"
 

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -79,7 +79,7 @@ class TestMlflowConfig:
 
     def test_creates_op_with_config(self, simple_pipeline, simple_catalog, mocker):
         """Test that ops can be created when mlflow_config is provided."""
-        mocker.patch("kedro_dagster.nodes._get_node_pipeline_name", return_value="test_pipeline")
+        mocker.patch("kedro_dagster.nodes._get_node_group_name", return_value="test_pipeline")
 
         mock_config = SimpleNamespace(ui=SimpleNamespace(host="localhost", port=5000))
 
@@ -106,7 +106,7 @@ class TestMlflowExecution:
 
     def test_without_mlflow_resource(self, simple_pipeline, simple_catalog, mocker):
         """Test that op executes correctly when MLflow resource is not available."""
-        mocker.patch("kedro_dagster.nodes._get_node_pipeline_name", return_value="test_pipeline")
+        mocker.patch("kedro_dagster.nodes._get_node_group_name", return_value="test_pipeline")
 
         node_translator = NodeTranslator(
             pipelines=[simple_pipeline],
@@ -131,7 +131,7 @@ class TestMlflowExecution:
 
     def test_with_no_active_run(self, simple_pipeline, simple_catalog, mocker):
         """Test that op executes correctly when MLflow resource exists but no active run."""
-        mocker.patch("kedro_dagster.nodes._get_node_pipeline_name", return_value="test_pipeline")
+        mocker.patch("kedro_dagster.nodes._get_node_group_name", return_value="test_pipeline")
 
         mlflow_resource = mocker.Mock()
         named_resources = {"mlflow": dg.ResourceDefinition.hardcoded_resource(mlflow_resource)}
@@ -164,7 +164,7 @@ class TestMlflowExecution:
 
     def test_with_active_run(self, simple_pipeline, simple_catalog, mocker):
         """Test that op captures MLflow metadata when an active run exists."""
-        mocker.patch("kedro_dagster.nodes._get_node_pipeline_name", return_value="test_pipeline")
+        mocker.patch("kedro_dagster.nodes._get_node_group_name", return_value="test_pipeline")
 
         mlflow_resource = mocker.Mock()
         named_resources = {"mlflow": dg.ResourceDefinition.hardcoded_resource(mlflow_resource)}
@@ -221,7 +221,7 @@ class TestMlflowMetadata:
 
     def test_url_metadata_value(self, simple_pipeline, simple_catalog, mocker):
         """Test that MLflow URL is wrapped in MetadataValue.url for asset materialization."""
-        mocker.patch("kedro_dagster.nodes._get_node_pipeline_name", return_value="test_pipeline")
+        mocker.patch("kedro_dagster.nodes._get_node_group_name", return_value="test_pipeline")
 
         mlflow_resource = mocker.Mock()
         named_resources = {"mlflow": dg.ResourceDefinition.hardcoded_resource(mlflow_resource)}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,9 +11,12 @@ from pydantic import BaseModel, ValidationError
 
 from kedro_dagster.datasets import DagsterNothingDataset
 from kedro_dagster.utils import (
+    SUPPORTS_HIERARCHICAL_GROUPS,
     _create_pydantic_model_from_dict,
-    _get_node_pipeline_name,
+    _get_node_group_name,
     _is_param_name,
+    _normalize_group_name,
+    _normalize_group_override,
     format_dataset_name,
     format_node_name,
     format_partition_key,
@@ -166,19 +169,38 @@ class TestIsParamName:
         assert _is_param_name("params:my_param")
 
 
-class TestGetNodePipelineName:
-    """Tests for _get_node_pipeline_name."""
+class TestGetNodeGroupName:
+    """Tests for _get_node_group_name."""
 
-    def test_infers_pipeline_name_from_registry(self, monkeypatch):
-        """Infer the pipeline name a node belongs to from the pipelines registry."""
+    def test_namespaced_node_groups_by_namespace(self, monkeypatch):
+        """A namespaced node groups by its namespace, not by the pipeline name."""
         mock_node = SimpleNamespace(name="test.node")
         mock_pipeline = SimpleNamespace(nodes=[mock_node])
 
         monkeypatch.setattr("kedro.framework.project.find_pipelines", lambda: {"pipeline": mock_pipeline})
 
-        pipeline_name = _get_node_pipeline_name(mock_node)
+        # Namespace "test" is a single segment: same on both Dagster capabilities,
+        # and the pipeline name ("pipeline") is no longer appended.
+        assert _get_node_group_name(mock_node) == "test"
 
-        assert pipeline_name == "test__pipeline"
+    def test_nested_namespace_uses_hierarchical_group(self, monkeypatch):
+        """A nested namespace maps to a hierarchical group using the active separator."""
+        mock_node = SimpleNamespace(name="marketing.ads.node")
+        mock_pipeline = SimpleNamespace(nodes=[mock_node])
+
+        monkeypatch.setattr("kedro.framework.project.find_pipelines", lambda: {"pipeline": mock_pipeline})
+
+        expected = "marketing/ads" if SUPPORTS_HIERARCHICAL_GROUPS else "marketing__ads"
+        assert _get_node_group_name(mock_node) == expected
+
+    def test_namespace_equal_to_pipeline_name_is_not_doubled(self, monkeypatch):
+        """namespace == pipeline name yields a single segment, not data_science__data_science."""
+        mock_node = SimpleNamespace(name="data_science.node")
+        mock_pipeline = SimpleNamespace(nodes=[mock_node])
+
+        monkeypatch.setattr("kedro.framework.project.find_pipelines", lambda: {"data_science": mock_pipeline})
+
+        assert _get_node_group_name(mock_node) == "data_science"
 
     def test_returns_none_and_warns_when_node_not_found(self, monkeypatch, caplog):
         """Return '__none__' and log a warning when the node is not in any pipeline."""
@@ -188,10 +210,115 @@ class TestGetNodePipelineName:
         )
 
         with caplog.at_level("WARNING"):
-            result = _get_node_pipeline_name(mock_node)
+            result = _get_node_group_name(mock_node)
 
             assert result == "__none__"
             assert "not part of any pipelines" in caplog.text
+
+
+class TestGroupNameNormalization:
+    """Tests for _normalize_group_name / _normalize_group_override across Dagster capabilities."""
+
+    def test_hierarchical_separator_when_supported(self, monkeypatch):
+        """Segments join with '/' when Dagster supports hierarchical groups."""
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", True)
+
+        assert _normalize_group_name(["marketing", "ads"]) == "marketing/ads"
+        assert _normalize_group_name(["marketing"]) == "marketing"
+
+    def test_flat_separator_when_unsupported(self, monkeypatch):
+        """Segments fall back to '__' on Dagster < 1.13.9; no '/' is emitted."""
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", False)
+
+        result = _normalize_group_name(["marketing", "ads"])
+        assert result == "marketing__ads"
+        assert "/" not in result
+
+    def test_segments_are_sanitized(self, monkeypatch):
+        """Non-alphanumeric characters within a segment are replaced, '/' only separates."""
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", True)
+
+        assert _normalize_group_name(["a.b", "c-d"]) == "a__b/c__d"
+
+    def test_empty_segments_are_dropped(self, monkeypatch):
+        """Empty segments (e.g. from a trailing '/') are dropped to keep the name valid."""
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", True)
+
+        assert _normalize_group_name(["marketing", ""]) == "marketing"
+
+    def test_override_with_hierarchy_when_supported(self, monkeypatch):
+        """A '/'-containing override nests on supported Dagster."""
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", True)
+
+        assert _normalize_group_override("marketing/ads") == "marketing/ads"
+
+    def test_override_without_hierarchy_is_unchanged(self, monkeypatch):
+        """A plain override (no '/') is preserved on both capabilities."""
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", True)
+        assert _normalize_group_override("custom_output_group") == "custom_output_group"
+
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", False)
+        assert _normalize_group_override("custom_output_group") == "custom_output_group"
+
+    def test_override_with_hierarchy_degrades_with_warning(self, monkeypatch, caplog):
+        """A '/'-containing override degrades to '__' with a warning on old Dagster, not an error."""
+        monkeypatch.setattr("kedro_dagster.utils.SUPPORTS_HIERARCHICAL_GROUPS", False)
+
+        with caplog.at_level("WARNING"):
+            result = _normalize_group_override("marketing/ads")
+
+        assert result == "marketing__ads"
+        assert "require Dagster >= 1.13.9" in caplog.text
+
+
+@pytest.mark.skipif(
+    not SUPPORTS_HIERARCHICAL_GROUPS,
+    reason="Hierarchical '/' asset groups require Dagster >= 1.13.9",
+)
+class TestHierarchicalGroupSelection:
+    """Smoke tests: Dagster accepts '/'-separated groups and they stay selectable."""
+
+    @staticmethod
+    def _asset_graph():
+        @dg.asset(group_name="marketing/ads")
+        def ads(): ...
+
+        @dg.asset(group_name="marketing/email")
+        def email(): ...
+
+        # The flat "external" group must keep working alongside hierarchical ones.
+        @dg.asset(group_name="external")
+        def upstream(): ...
+
+        return dg.Definitions(assets=[ads, email, upstream]).resolve_asset_graph()
+
+    def test_hierarchical_group_is_accepted_and_selectable(self):
+        """A '/'-separated group name is valid and resolvable via an exact group selection."""
+        asset_graph = self._asset_graph()
+
+        selected = dg.AssetSelection.groups("marketing/ads").resolve(asset_graph)
+
+        assert {str(k) for k in selected} == {"AssetKey(['ads'])"}
+
+    def test_subtree_is_addressable_by_hierarchical_groups(self):
+        """The `marketing` subtree is addressable through its hierarchical group names.
+
+        The Dagster UI exposes this as the `group:"marketing/*"` wildcard query; at the
+        Python API level the same subtree is the union of its leaf group selections.
+        """
+        asset_graph = self._asset_graph()
+
+        subtree = dg.AssetSelection.groups("marketing/ads") | dg.AssetSelection.groups("marketing/email")
+
+        assert {str(k) for k in subtree.resolve(asset_graph)} == {"AssetKey(['ads'])", "AssetKey(['email'])"}
+
+    def test_external_group_unchanged(self):
+        """The flat 'external' group is still valid and selectable."""
+        asset_graph = self._asset_graph()
+
+        selected = dg.AssetSelection.groups("external").resolve(asset_graph)
+
+        assert {str(k) for k in selected} == {"AssetKey(['upstream'])"}
 
 
 class TestGetFilterParamsDict:
@@ -554,8 +681,8 @@ class TestPydanticModelNoneValues:
         assert instance2.nullable_field == "hello"
 
 
-class TestGetNodePipelineNameNonNamespaced:
-    """Test _get_node_pipeline_name with non-namespaced node names."""
+class TestGetNodeGroupNameNonNamespaced:
+    """Test _get_node_group_name with non-namespaced node names."""
 
     def test_non_namespaced_node_returns_pipeline_name(self, monkeypatch):
         """Return plain pipeline name for non-namespaced node (no dots)."""
@@ -564,7 +691,7 @@ class TestGetNodePipelineNameNonNamespaced:
 
         monkeypatch.setattr("kedro.framework.project.find_pipelines", lambda: {"my_pipeline": mock_pipeline})
 
-        result = _get_node_pipeline_name(mock_node)
+        result = _get_node_group_name(mock_node)
         assert result == "my_pipeline"
 
     def test_skips_default_pipeline(self, monkeypatch):
@@ -578,7 +705,7 @@ class TestGetNodePipelineNameNonNamespaced:
             lambda: {"__default__": default_pipeline, "data_processing": named_pipeline},
         )
 
-        result = _get_node_pipeline_name(mock_node)
+        result = _get_node_group_name(mock_node)
         assert result == "data_processing"
 
     def test_iterates_past_non_matching_nodes(self, monkeypatch):
@@ -592,7 +719,7 @@ class TestGetNodePipelineNameNonNamespaced:
             lambda: {"pipeline_a": pipeline_with_both},
         )
 
-        result = _get_node_pipeline_name(target_node)
+        result = _get_node_group_name(target_node)
         assert result == "pipeline_a"
 
     def test_iterates_past_non_matching_pipelines(self, monkeypatch):
@@ -607,5 +734,5 @@ class TestGetNodePipelineNameNonNamespaced:
             lambda: {"pipeline_a": pipeline_a, "pipeline_b": pipeline_b},
         )
 
-        result = _get_node_pipeline_name(target_node)
+        result = _get_node_group_name(target_node)
         assert result == "pipeline_b"


### PR DESCRIPTION
## Description

Derive each asset's Dagster **group** from its Kedro **namespace**, rendered hierarchically with `/` on Dagster ≥ 1.13.9 (e.g. `marketing.ads` → `marketing/ads`) and falling back to `__` on older Dagster. Nested groups render as a tree in the asset graph and support wildcard selection (`group:"marketing/*"`).

The pipeline name is no longer folded into a namespaced node's group — Kedro pipelines already map to Dagster jobs, so the namespace alone defines the group. This also removes redundant names like `data_science__data_science`. Catalog `metadata["group_name"]` overrides flow through the same version-gated normalizer and degrade `/` → `__` with a warning instead of raising on older Dagster. External inputs keep the flat `external` group.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Kedro's modular pipelines express hierarchy through namespaces; Dagster 1.13.9+ lets asset group names carry that hierarchy via `/`. Mapping namespaces onto hierarchical groups keeps the Dagster asset graph aligned with the Kedro modular-pipeline structure and enables subtree selection.

**Breaking change:** namespaced asset group names change shape (`namespace__pipeline` → `namespace` / `namespace/...`). Update any group-based asset selections, schedules, or sensors accordingly.

Relates to #119

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- Capability is detected once via `SUPPORTS_HIERARCHICAL_GROUPS` (built on the existing `DAGSTER_VERSION` tuple — no new dependency, no `pyproject.toml` pin change) and applied by `_get_node_group_name` / `_normalize_group_name` in `utils.py`.
- The private helper `_get_node_pipeline_name` was renamed to `_get_node_group_name`, since its return value is now a group rather than a pipeline name.
- Follow-on (out of scope): exposing `group:"marketing/*"` wildcard selection in `dagster.yml` job/schedule definitions, alongside the existing `node_namespaces` filter.
