### PR TITLE
feat: add job factory deriving jobs from pipeline namespaces

### DIFF
--- a/docs/pages/explanation/concepts.md
+++ b/docs/pages/explanation/concepts.md
@@ -33,6 +33,10 @@ See the [Kedro documentation](https://docs.kedro.org/) and the [Kedro starters](
 
 Orchestration settings live in a `dagster.yml` file per Kedro environment rather than being scattered across Python code. This keeps infrastructure concerns (which executor to use, what schedule to run) separate from pipeline logic, and makes it possible to change deployment behavior without modifying a single line of Python. See the [configuration reference](../reference/configuration.md) for all available fields.
 
+### Job factories
+
+Just as [Kedro dataset factories](https://docs.kedro.org/en/stable/catalog-data/kedro_dataset_factories/) collapse repetitive catalog entries into one templated rule, a **job factory** collapses repetitive `jobs:` entries. A key with `{placeholder}` markers expands into one Dagster job per pipeline node namespace, so running the same pipeline across many products, regions, or model variants is a single templated definition instead of copy-paste. See [How to Use Job Factories](../how-to/use-job-factories.md).
+
 ### Customization
 
 The translation produces a standard Dagster `definitions.py` that serves as the project entry point. Because it is regular Python, you can extend or override any part of the generated definitions for specialized requirements such as custom resources or deployment patterns.

--- a/docs/pages/how-to/index.md
+++ b/docs/pages/how-to/index.md
@@ -6,6 +6,7 @@ Practical directions for common tasks. Each guide addresses a specific goal and 
 
 - **[How to Configure Logging](configure-logging.md)**: Unify Kedro and Dagster logs and customize formatters.
 - **[How to Configure Custom Executors](configure-executors.md)**: Set up multiprocess, Docker, Kubernetes, Dask, or Celery executors.
+- **[How to Use Job Factories](use-job-factories.md)**: Replace repeated per-namespace jobs with a single templated factory.
 
 ## Integration
 

--- a/docs/pages/how-to/use-job-factories.md
+++ b/docs/pages/how-to/use-job-factories.md
@@ -1,0 +1,135 @@
+# How to Use Job Factories
+
+This guide shows you how to replace repeated, near-identical job definitions with a single **job factory** that expands into one Dagster job per Kedro pipeline namespace. Use this when you run the same pipeline across several namespaces (products, regions, model variants) and your `jobs:` block is mostly copy-paste.
+
+Job factories are the job-level analogue of [Kedro dataset factories](https://docs.kedro.org/en/stable/catalog-data/kedro_dataset_factories/): one templated entry stands in for many concrete ones.
+
+## Prerequisites
+
+- A working Kedro-Dagster project ([Getting Started](../tutorials/getting-started.md))
+- One or more pipelines whose nodes carry [namespaces](https://docs.kedro.org/en/stable/build/namespace_pipelines/) (e.g. `reviews_predictor.train_model`)
+
+## How job factories work
+
+A `jobs:` key that contains `{placeholder}` markers is a **factory**. Its concrete jobs are derived from the node namespaces of the pipeline it targets. The first `node_namespaces` entry is the *binding axis*: each `{placeholder}` binds to the matching part of a node's namespace, and the pipeline's distinct namespaces (at that depth) each produce one job.
+
+```yaml
+jobs:
+  "{product}__data_processing":
+    pipeline:
+      pipeline_name: data_processing
+      node_namespaces: ["{product}"]   # binding axis: {product} = each namespace
+```
+
+Rendered job names must be valid Dagster names (`[A-Za-z0-9_]`), so placeholder-derived parts use single `_` and the fixed job-type tail is separated by `__`.
+
+## Convert repeated jobs into a factory
+
+Suppose you run the same two pipelines for two products. Written out by hand, that is four jobs:
+
+```yaml
+jobs:
+  reviews_predictor_data_processing:
+    pipeline: { pipeline_name: data_processing, node_namespaces: [reviews_predictor] }
+    executor: multiprocessing
+  price_predictor_data_processing:
+    pipeline: { pipeline_name: data_processing, node_namespaces: [price_predictor] }
+    executor: multiprocessing
+  reviews_predictor_data_science:
+    pipeline: { pipeline_name: data_science, node_namespaces: [reviews_predictor] }
+    executor: sequential
+  price_predictor_data_science:
+    pipeline: { pipeline_name: data_science, node_namespaces: [price_predictor] }
+    executor: sequential
+```
+
+Because the product is the only thing that varies, collapse each pipeline into one factory:
+
+```yaml
+jobs:
+  "{product}__data_processing":
+    pipeline:
+      pipeline_name: data_processing
+      node_namespaces: ["{product}"]
+    executor: multiprocessing
+  "{product}__data_science":
+    pipeline:
+      pipeline_name: data_science
+      node_namespaces: ["{product}"]
+    executor: sequential
+```
+
+`{product}` binds to `reviews_predictor` and `price_predictor`, so these two keys render the same four jobs — `reviews_predictor__data_processing`, `price_predictor__data_processing`, and the `data_science` pair.
+
+## Bind deeper namespaces
+
+The binding axis is split on `.`, so a template can bind several placeholders across a nested namespace. A pipeline with nodes in `da_energy.hub.champion`, `rt_energy.hub.challenger`, … can be captured with:
+
+```yaml
+jobs:
+  "{product}__{group}__{variant}__inference":
+    pipeline:
+      pipeline_name: inference
+      node_namespaces: ["{product}.{group}.{variant}"]
+```
+
+A literal segment in the axis restricts which namespaces match — `node_namespaces: ["rt_energy.{group}.{variant}"]` only binds namespaces beginning with `rt_energy`.
+
+## Interpolate the whole job body
+
+Placeholders are substituted into **every** string in the job body, not just the key. This lets a factory select a per-namespace executor:
+
+```yaml
+executors:
+  reviews_predictor_executor:
+    multiprocess: { max_concurrent: 2 }
+  price_predictor_executor:
+    in_process:
+
+jobs:
+  "{product}__data_processing":
+    pipeline:
+      pipeline_name: data_processing
+      node_namespaces: ["{product}"]
+    executor: "{product}_executor"   # renders to reviews_predictor_executor / price_predictor_executor
+```
+
+The same works for `schedule` and `loggers` references.
+
+## Preview the expansion
+
+Check what a factory renders **without** starting Dagster:
+
+```bash
+# List the factory keys ({placeholder} entries) in dagster.yml
+kedro dagster list-patterns -e <env>
+
+# Print the concrete jobs the factories render, with pipeline, namespaces, and schedule
+kedro dagster resolve-patterns -e <env>
+```
+
+These mirror `kedro catalog list-patterns` / `resolve-patterns` and are the fastest way to confirm bindings while authoring a factory.
+
+## Mix factories with literal jobs
+
+Factory and literal (non-templated) jobs coexist. A literal job with the same rendered name **wins**, so you can override a single case while a factory handles the rest:
+
+```yaml
+jobs:
+  "{product}__data_science":
+    pipeline: { pipeline_name: data_science, node_namespaces: ["{product}"] }
+    executor: sequential
+  price_predictor__data_science:   # literal override for one product
+    pipeline: { pipeline_name: data_science, node_namespaces: [price_predictor] }
+    executor: multiprocessing
+```
+
+!!! note "A factory only renders namespaces that exist"
+    Jobs are derived from the **pipeline's** namespaces in the active environment. If a namespace is absent (or lacks the `tags` your factory filters on), no job is rendered for it — keep single-namespace or specially-filtered cases as literal jobs.
+
+## See also
+
+- [Configuration Reference — Job factories](../reference/configuration.md#job-factories): field-level detail and precedence rules
+- [CLI Reference](../reference/cli.md#kedro-dagster-resolve-patterns): `resolve-patterns` / `list-patterns`
+- [Example Project](../tutorials/example-project.md): job factories in the `staging` and `prod` environments
+- [`PipelineOptions`](../api/generated/kedro_dagster.config.models.PipelineOptions.md): all pipeline filter parameters

--- a/docs/pages/how-to/use-job-factories.md
+++ b/docs/pages/how-to/use-job-factories.md
@@ -63,7 +63,7 @@ jobs:
 
 ## Bind deeper namespaces
 
-The binding axis is split on `.`, so a template can bind several placeholders across a nested namespace. A pipeline with nodes in `da_energy.hub.champion`, `rt_energy.hub.challenger`, … can be captured with:
+The binding axis is split on `.`, so a template can bind several placeholders across a nested namespace. A pipeline with nodes in `alpha.hub.champion`, `beta.hub.challenger`, … can be captured with:
 
 ```yaml
 jobs:
@@ -73,7 +73,7 @@ jobs:
       node_namespaces: ["{product}.{group}.{variant}"]
 ```
 
-A literal segment in the axis restricts which namespaces match — `node_namespaces: ["rt_energy.{group}.{variant}"]` only binds namespaces beginning with `rt_energy`.
+A literal segment in the axis restricts which namespaces match — `node_namespaces: ["beta.{group}.{variant}"]` only binds namespaces beginning with `beta`.
 
 ## Interpolate the whole job body
 

--- a/docs/pages/reference/cli.md
+++ b/docs/pages/reference/cli.md
@@ -118,6 +118,52 @@ kedro dagster list-defs -e production
 
 ---
 
+## `kedro dagster resolve-patterns`
+
+Print the concrete jobs a [job factory](configuration.md#job-factories) expands to, derived from the active pipeline namespaces, plus any literal jobs. Each line shows the job name with its pipeline, node namespaces, and schedule. No Dagster code location is built, so this is a fast preview while authoring factory keys. Mirrors `kedro catalog resolve-patterns`.
+
+```text
+kedro dagster resolve-patterns [OPTIONS]
+```
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--env` | `-e` | Kedro configuration environment to load | `local` |
+
+### Examples
+
+```bash
+# Preview the jobs the factories render for an environment
+kedro dagster resolve-patterns -e staging
+```
+
+---
+
+## `kedro dagster list-patterns`
+
+List the job-factory keys (`jobs:` keys containing `{placeholder}` markers) defined in `dagster.yml`. Literal (non-factory) jobs are not listed. Mirrors `kedro catalog list-patterns`.
+
+```text
+kedro dagster list-patterns [OPTIONS]
+```
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--env` | `-e` | Kedro configuration environment to load | `local` |
+
+### Examples
+
+```bash
+# List the factory keys defined for an environment
+kedro dagster list-patterns -e staging
+```
+
+---
+
 ## Proxied `dg` Commands
 
 With Dagster >= 1.10.6, all commands from the `dg` CLI are available under `kedro dagster`. Each proxied command receives an additional `--env/-e` option to specify the Kedro environment. All other arguments are forwarded to the underlying `dg` command.

--- a/docs/pages/reference/configuration.md
+++ b/docs/pages/reference/configuration.md
@@ -43,6 +43,38 @@ Each job maps a [Kedro pipeline](https://docs.kedro.org/en/stable/build/pipeline
 
 Accepted pipeline parameters: [`PipelineOptions`](../api/generated/kedro_dagster.config.models.PipelineOptions.md).
 
+### Job factories
+
+A `jobs:` key that contains `{placeholder}` markers is a **job factory** — the job-level analogue of a [Kedro dataset factory](https://docs.kedro.org/en/stable/catalog-data/kedro_dataset_factories/). Instead of writing one job per namespace by hand, a factory renders one concrete job per **pipeline node namespace**.
+
+The first `node_namespaces` entry is the *binding axis*: it is split on `.`, and each segment is either a `{placeholder}` (bound to that part of a node's namespace) or a literal (which must match). The distinct namespaces of the factory's `pipeline_name` pipeline, at the axis depth, become the jobs:
+
+```yaml
+jobs:
+  "{product}__data_processing_candidate1":
+    pipeline:
+      pipeline_name: data_processing
+      node_namespaces: ["{product}"] # binding axis: {product} = each namespace
+      tags: [candidate1]
+    executor: multiprocessing
+    schedule: daily
+```
+
+If the `data_processing` pipeline has nodes in the namespaces `reviews_predictor` and `price_predictor`, this single key renders two jobs: `reviews_predictor__data_processing_candidate1` and `price_predictor__data_processing_candidate1`, each with the interpolated body.
+
+Key points:
+
+- **Names render forward only.** A concrete name is produced by substituting the binding into the factory key; names are never reverse-parsed. The fixed job-type tail is separated from the placeholder-derived part by `__`, so `{product}__data_processing_candidate1` becomes `reviews_predictor__data_processing_candidate1` (single `_` inside the namespace value, `__` before the tail). Rendered names are valid Dagster names (`[A-Za-z0-9_]`).
+- **The whole body is interpolated.** Placeholders are substituted into every string in the job body — including references such as `executor: "{product}_executor"` — not just the key.
+- **Literal jobs win.** A `jobs:` key without markers is a literal job; on a name collision it takes precedence over a rendered one. When several factories render the same name, the most-specific (most literal characters) supplies the body.
+
+Preview the expansion without launching Dagster:
+
+```bash
+kedro dagster list-patterns -e <env>     # the factory ({placeholder}) keys
+kedro dagster resolve-patterns -e <env>  # the concrete jobs they render
+```
+
 ### Executors
 
 Define how jobs are executed: in-process, multiprocess, Docker, Celery, Kubernetes, etc. Each entry corresponds to a [Dagster executor](https://docs.dagster.io/guides/operate/run-executors#example-executors).

--- a/docs/pages/reference/configuration.md
+++ b/docs/pages/reference/configuration.md
@@ -75,6 +75,8 @@ kedro dagster list-patterns -e <env>     # the factory ({placeholder}) keys
 kedro dagster resolve-patterns -e <env>  # the concrete jobs they render
 ```
 
+For a step-by-step walkthrough, see [How to Use Job Factories](../how-to/use-job-factories.md).
+
 ### Executors
 
 Define how jobs are executed: in-process, multiprocess, Docker, Celery, Kubernetes, etc. Each entry corresponds to a [Dagster executor](https://docs.dagster.io/guides/operate/run-executors#example-executors).

--- a/docs/pages/tutorials/example-project.md
+++ b/docs/pages/tutorials/example-project.md
@@ -131,7 +131,7 @@ The example defines four environments under `conf/<ENV>/`, each with its own `ca
 - **`dev`**: Multiprocessing, scheduling, and the `model_tuning` pipeline. Requires a Postgres database (see below).
 - **`staging`** and **`prod`**: Production-style configuration with multiprocessing and cron schedules.
 
-Here is a trimmed `conf/prod/dagster.yml` showing how loggers, executors, schedules, and jobs fit together:
+Here is a trimmed `conf/staging/dagster.yml` showing how loggers, executors, schedules, and jobs fit together. The `jobs` block uses **job factories** — keys with a `{product}` placeholder that expand into one job per pipeline namespace:
 
 ```yaml
 loggers:
@@ -173,30 +173,32 @@ schedules:
     cron_schedule: "30 2 * * *"
 
 jobs:
-  reviews_predictor_data_processing_base:
+  # Job factories: '{product}' binds to each namespace of the pipeline
+  # (reviews_predictor, price_predictor), so each key renders one job per product.
+  "{product}__data_processing_candidate1":
     pipeline:
       pipeline_name: data_processing
       node_namespaces:
-      - reviews_predictor
+      - "{product}"
       tags:
-      - base
-    loggers: ["console_logger", "file_logger"]
+      - candidate1
+    loggers: ["file_logger", "console_logger"]
     executor: multiprocessing
     schedule: daily
 
-  reviews_predictor_data_science_base:
+  "{product}__data_science_candidate1":
     pipeline:
       pipeline_name: data_science
       node_namespaces:
-      - reviews_predictor
+      - "{product}"
       tags:
-      - base
-    loggers: ["console_logger", "file_logger"]
-    executor: multiprocessing
+      - candidate1
+    loggers: ["file_logger", "console_logger"]
+    executor: sequential
     schedule: daily
 ```
 
-Notice that each Dagster job is generated from a filtered Kedro pipeline (selected by `pipeline_name` and narrowed by `node_namespaces` or `tags`). See [`PipelineOptions`](../api/generated/kedro_dagster.config.models.PipelineOptions.md) for all filtering parameters.
+Each Dagster job is generated from a filtered Kedro pipeline (selected by `pipeline_name` and narrowed by `node_namespaces` or `tags`; see [`PipelineOptions`](../api/generated/kedro_dagster.config.models.PipelineOptions.md)). Here the two `{product}` **job factories** render one job per namespace — `reviews_predictor__data_processing_candidate1`, `price_predictor__data_processing_candidate1`, and the `data_science` pair. Preview what a factory expands to with `kedro dagster resolve-patterns -e staging`, and see [How to Use Job Factories](../how-to/use-job-factories.md). The `prod` environment goes further, interpolating `{product}` into a per-product `executor` reference.
 
 ## Partitions in practice
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ nav:
     - pages/how-to/index.md
     - Configure Logging: pages/how-to/configure-logging.md
     - Configure Executors: pages/how-to/configure-executors.md
+    - Use Job Factories: pages/how-to/use-job-factories.md
     - Use Partitions: pages/how-to/use-partitions.md
     - Use MLflow: pages/how-to/use-mlflow.md
     - Deploy to Production: pages/how-to/deploy-to-production.md

--- a/src/kedro_dagster/cli/commands.py
+++ b/src/kedro_dagster/cli/commands.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 import click
 from dagster_dg_cli.cli import create_dg_cli
 
-from kedro_dagster.cli.functions import scaffold_dagster_files
+from kedro_dagster.cli.functions import list_job_patterns, resolve_job_patterns, scaffold_dagster_files
 from kedro_dagster.utils import DAGSTER_VERSION, find_kedro_project
 
 LOGGER = getLogger(__name__)
@@ -84,6 +84,58 @@ def init(env: str, force: bool, silent: bool) -> None:
     >>> kedro dagster init -e base --silent
     """
     scaffold_dagster_files(env=env, force=force, silent=silent)
+
+
+@dagster_commands.command(name="resolve-patterns")
+@click.option(
+    "--env",
+    "-e",
+    default="local",
+    help="The Kedro environment to load.",
+)
+def resolve_patterns(env: str) -> None:
+    """Print the concrete jobs derived from the job factories and pipelines.
+
+    The analogue of ``kedro catalog resolve-patterns``: renders every job factory
+    (``jobs`` keys containing ``{placeholder}`` markers) against the active pipeline
+    namespaces, plus any literal jobs, and lists the resulting job names with their
+    pipeline, node namespaces, and schedule. No Dagster code location is built.
+
+    Parameters
+    ----------
+    env : str
+        Kedro configuration environment to load. Defaults to ``"local"``.
+
+    Examples
+    --------
+    >>> kedro dagster resolve-patterns -e local
+    """
+    resolve_job_patterns(env=env)
+
+
+@dagster_commands.command(name="list-patterns")
+@click.option(
+    "--env",
+    "-e",
+    default="local",
+    help="The Kedro environment to load.",
+)
+def list_patterns(env: str) -> None:
+    """List the job-factory keys (``jobs`` keys containing ``{placeholder}`` markers).
+
+    The analogue of ``kedro catalog list-patterns``. Literal (non-factory) job keys
+    are not listed.
+
+    Parameters
+    ----------
+    env : str
+        Kedro configuration environment to load. Defaults to ``"local"``.
+
+    Examples
+    --------
+    >>> kedro dagster list-patterns -e local
+    """
+    list_job_patterns(env=env)
 
 
 if DAGSTER_VERSION >= (1, 10, 6):

--- a/src/kedro_dagster/cli/functions.py
+++ b/src/kedro_dagster/cli/functions.py
@@ -2,10 +2,14 @@
 
 from logging import getLogger
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import click
 
 from kedro_dagster.utils import DAGSTER_VERSION, find_kedro_project, write_jinja_template
+
+if TYPE_CHECKING:
+    from kedro_dagster.config import KedroDagsterConfig, ScheduleOptions
 
 LOGGER = getLogger(__name__)
 TEMPLATE_FOLDER_PATH = Path(__file__).parent.parent / "templates"
@@ -121,3 +125,100 @@ def scaffold_dagster_files(env: str, force: bool, silent: bool) -> None:
                         fg="green",
                     )
                 )
+
+
+def _load_config_and_pipelines(env: str) -> tuple["KedroDagsterConfig", dict[str, Any]]:
+    """Load the Dagster config and the registered pipelines for *env*.
+
+    Bootstraps the Kedro project, opens a session, and reads the Dagster
+    configuration plus the project's registered pipelines — the same inputs the
+    translator feeds to the job factory — without building a Dagster code location.
+
+    Parameters
+    ----------
+    env : str
+        Kedro configuration environment to load.
+
+    Returns
+    -------
+    tuple[KedroDagsterConfig, dict[str, Any]]
+        The parsed Dagster configuration and the registered pipelines by name.
+    """
+    # Lazy imports to avoid circular dependency and keep CLI import light
+    from kedro.framework.project import pipelines
+    from kedro.framework.session import KedroSession
+    from kedro.framework.startup import bootstrap_project
+
+    from kedro_dagster.config import get_dagster_config
+
+    project_path = find_kedro_project(Path.cwd()) or Path.cwd()
+    bootstrap_project(project_path)
+    # Mirror `KedroProjectTranslator.initialize_kedro`: assign the created session
+    # (typed `KedroSession`) rather than binding the `with ... as` target, whose
+    # `AbstractSession` type lacks `load_context`.
+    session = KedroSession.create(project_path=project_path, env=env)
+    context = session.load_context()
+    dagster_config = get_dagster_config(context)
+    # Materialize the lazy pipeline registry into a plain dict.
+    registered_pipelines = dict(pipelines)
+    return dagster_config, registered_pipelines
+
+
+def _format_schedule(schedule: "ScheduleOptions | str") -> str:
+    """Render a job's schedule (named reference or inline options) for display."""
+    if isinstance(schedule, str):
+        return schedule
+    return getattr(schedule, "cron_schedule", None) or "<inline>"
+
+
+def resolve_job_patterns(env: str) -> None:
+    """Print the concrete jobs derived from the job factories and pipelines.
+
+    The analogue of ``kedro catalog resolve-patterns``: renders every job factory
+    against the active pipeline namespaces (plus any literal jobs) and lists the
+    resulting job names with their pipeline, node namespaces, and schedule. No
+    Dagster code location is constructed.
+
+    Parameters
+    ----------
+    env : str
+        Kedro configuration environment to load.
+    """
+    from kedro_dagster.factory import enumerate_jobs
+
+    dagster_config, registered_pipelines = _load_config_and_pipelines(env)
+    jobs = enumerate_jobs(dagster_config, registered_pipelines)
+    if not jobs:
+        click.echo("No jobs resolved (no job factories or literal jobs in dagster.yml).")
+        return
+    for name in sorted(jobs):
+        job = jobs[name]
+        detail = [f"pipeline={job.pipeline.pipeline_name}"]
+        namespaces = ", ".join(job.pipeline.node_namespaces or [])
+        if namespaces:
+            detail.append(f"namespaces=[{namespaces}]")
+        if job.schedule:
+            detail.append(f"schedule={_format_schedule(job.schedule)}")
+        click.echo(f"{name}  ({'; '.join(detail)})")
+
+
+def list_job_patterns(env: str) -> None:
+    """List the job-factory keys (``jobs`` keys containing ``{placeholder}`` markers).
+
+    The analogue of ``kedro catalog list-patterns``. Literal (non-factory) job
+    keys are not listed.
+
+    Parameters
+    ----------
+    env : str
+        Kedro configuration environment to load.
+    """
+    from kedro_dagster.factory import is_factory
+
+    dagster_config, _ = _load_config_and_pipelines(env)
+    patterns = sorted(key for key in (dagster_config.jobs or {}) if is_factory(key))
+    if not patterns:
+        click.echo("No job factory patterns defined in dagster.yml.")
+        return
+    for pattern in patterns:
+        click.echo(pattern)

--- a/src/kedro_dagster/config/models.py
+++ b/src/kedro_dagster/config/models.py
@@ -1031,7 +1031,9 @@ class KedroDagsterConfig(BaseModel):
     schedules : dict[str, ScheduleOptions] or None
         Mapping of schedule names to schedule options.
     jobs : dict[str, JobOptions] or None
-        Mapping of job names to job options.
+        Mapping of job names to job options. A key containing ``{placeholder}``
+        markers is a job factory whose concrete jobs are derived from the Kedro
+        pipeline namespaces (see `kedro_dagster.factory`).
 
     Examples
     --------
@@ -1065,7 +1067,14 @@ class KedroDagsterConfig(BaseModel):
     loggers: dict[str, LoggerOptions] | None = None
     executors: dict[str, ExecutorOptions] | None = None
     schedules: dict[str, ScheduleOptions] | None = None
-    jobs: dict[str, JobOptions] | None = None
+    jobs: dict[str, JobOptions] | None = Field(
+        default=None,
+        description=(
+            "Named job definitions. A key containing '{placeholder}' markers is a job "
+            "factory whose concrete jobs are derived from the Kedro pipeline namespaces "
+            "(see `kedro_dagster.factory`); a key without markers is a literal job."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/src/kedro_dagster/factory.py
+++ b/src/kedro_dagster/factory.py
@@ -1,0 +1,318 @@
+"""Forward-only job factory resolution.
+
+A ``jobs`` key containing ``{placeholder}`` markers is a *job factory*: a
+templated job entry sharing the config surface of a Kedro dataset factory. The
+concrete jobs are derived from the Kedro pipeline namespaces. For each factory,
+its ``node_namespaces`` template defines the binding placeholders and their
+namespace depth, and the distinct namespaces of its pipeline become the jobs (the
+job analogue of a dataset factory, whose datasets are determined by pipeline node
+references).
+
+Names are produced only by rendering bindings forward; they are never
+reverse-parsed (a placeholder value can contain the ``_`` separator, e.g.
+``reviews_predictor``, which would make reverse-parsing ambiguous). The fixed
+job-type tail is separated from the placeholder-derived part by
+:data:`~kedro_dagster.constants.KEDRO_DAGSTER_SEPARATOR` (``__``) so it can be
+recovered unambiguously with ``rsplit("__")``; placeholder-derived parts keep
+single ``_``. Rendered names are valid Dagster names (``^[A-Za-z0-9_]+$``), which
+forbid the ``-`` used by the sibling ``kedro-azureml-pipeline`` plugin.
+
+* enumerate (schedule creation, listing): render every binding into its job.
+* resolve <name>: render all bindings (plus literal jobs) into a name -> job map
+  and look the requested name up.
+
+Each binding is tagged with its factory's job-type suffix, so a binding for one
+job type never matches a factory for another. When several factories render the
+same name, the most-specific one (most literal characters) supplies the config.
+"""
+
+from __future__ import annotations
+
+import string
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from kedro_dagster.config.models import JobOptions
+from kedro_dagster.constants import KEDRO_DAGSTER_SEPARATOR
+
+if TYPE_CHECKING:
+    from kedro_dagster.config.models import KedroDagsterConfig
+
+
+def _job_suffix(factory_key: str) -> str:
+    """Job-type suffix of a factory key (literal text after the last ``{token}``)."""
+    return factory_key.rsplit("}", 1)[-1].lstrip("_")
+
+
+def _ordered_tokens(template: str) -> list[str]:
+    """Field names in *template*, in order of appearance."""
+    return [name for _, name, _, _ in string.Formatter().parse(template) if name]
+
+
+def _bind_namespace(template: str, namespace: str) -> dict[str, str] | None:
+    """Bind a node *namespace* to the tokens of a `node_namespaces` *template*.
+
+    The template and namespace are split on ``.``; each template segment is either
+    a single ``{token}`` (bound to the namespace part) or a literal (which must
+    match the namespace part). Returns the binding, or ``None`` if the namespace is
+    shallower than the template or a literal segment does not match.
+    """
+    segments = template.split(".")
+    parts = namespace.split(".")
+    if len(parts) < len(segments):
+        return None
+    binding: dict[str, str] = {}
+    for segment, part in zip(segments, parts, strict=False):  # parts may be deeper than the template
+        tokens = _ordered_tokens(segment)
+        if tokens:
+            binding[tokens[0]] = part
+        elif segment != part:
+            return None
+    return binding
+
+
+def _derive_bindings(config: KedroDagsterConfig, pipelines: Mapping[str, Any] | None) -> list[dict[str, str]]:
+    """Derive job bindings from each factory's pipeline namespaces.
+
+    For each job factory, the factory's ``pipeline.node_namespaces`` template
+    defines the binding tokens and their namespace depth; the distinct namespaces
+    of the factory's ``pipeline_name`` pipeline at that depth become the bindings,
+    each tagged with the factory's job-type suffix. *pipelines* is the Kedro
+    pipeline registry; when ``None`` the global registry is used.
+
+    Only the *first* ``node_namespaces`` entry is the binding axis: it sets the
+    tokens and depth used here. Any further entries are not used for derivation;
+    they still render per binding (in :func:`_render_job`) as the rendered job's
+    runtime namespace filters, so a factory can derive its axis from the first
+    entry and carry extra static namespace filters in the rest.
+    """
+    if pipelines is None:
+        from kedro.framework.project import pipelines  # noqa: PLC0415
+
+    bindings: list[dict[str, str]] = []
+    seen: set[frozenset[tuple[str, str]]] = set()
+    for key, job in (config.jobs or {}).items():
+        if not is_factory(key):
+            continue
+        templates = job.pipeline.node_namespaces or []
+        pipe = pipelines.get(job.pipeline.pipeline_name)
+        if not templates or pipe is None:
+            continue
+        template = templates[0]
+        # Every token in the factory name must be bindable from the namespace
+        # template; otherwise the rendered name would keep an unfilled `{token}`.
+        unbindable = _tokens(key) - _tokens(template)
+        if unbindable:
+            raise ValueError(
+                f"Job factory '{key}' references token(s) {sorted(unbindable)} "
+                f"absent from its node_namespaces template '{template}'."
+            )
+        depth = len(template.split("."))
+        namespaces = {
+            ".".join(node.namespace.split(".")[:depth])
+            for node in pipe.nodes
+            if node.namespace and len(node.namespace.split(".")) >= depth
+        }
+        suffix = _job_suffix(key)
+        for namespace in namespaces:
+            binding = _bind_namespace(template, namespace)
+            if binding is None:
+                continue
+            binding["job"] = suffix
+            marker = frozenset(binding.items())
+            if marker in seen:
+                continue
+            seen.add(marker)
+            bindings.append(binding)
+    return bindings
+
+
+def is_factory(key: str) -> bool:
+    """True if a ``jobs`` key is a factory (contains ``{placeholder}`` markers)."""
+    return "{" in key and "}" in key
+
+
+def _tokens(template: str) -> set[str]:
+    """Field names referenced by ``{token}`` placeholders in *template*."""
+    return {name for _, name, _, _ in string.Formatter().parse(template) if name}
+
+
+def _literal_len(template: str) -> int:
+    """Total length of the literal (non-placeholder) text in *template*."""
+    return sum(len(literal or "") for literal, _, _, _ in string.Formatter().parse(template))
+
+
+def _render_str(value: str, tokens: dict[str, str]) -> str:
+    """``str.format`` *value* with *tokens*, but only if it has a fillable field.
+
+    Strings without ``{...}`` are returned unchanged. A leftover OmegaConf
+    ``${...}`` (already resolved at config-load time, so not expected here) or any
+    unknown field is tolerated by returning the original string rather than
+    raising, so ``{token}`` rendering never disturbs other interpolation syntax.
+    """
+    if "{" not in value or "}" not in value:
+        return value
+    try:
+        return value.format(**tokens)
+    except (KeyError, IndexError, ValueError):
+        return value
+
+
+def _render_value(value: Any, tokens: dict[str, str]) -> Any:
+    """Recursively interpolate string leaves of *value* (str/list/dict) with *tokens*."""
+    if isinstance(value, str):
+        return _render_str(value, tokens)
+    if isinstance(value, list):
+        return [_render_value(item, tokens) for item in value]
+    if isinstance(value, dict):
+        return {key: _render_value(item, tokens) for key, item in value.items()}
+    return value
+
+
+def _render_job(config: JobOptions | dict[str, Any], tokens: dict[str, str]) -> JobOptions:
+    """Render a factory's job config (``JobOptions`` or raw dict) by interpolating leaves."""
+    data = config.model_dump(exclude_none=True) if isinstance(config, JobOptions) else config
+    return JobOptions.model_validate(_render_value(data, tokens))
+
+
+def _matches_job_type(name: str, job: str | None) -> bool:
+    """True if rendered *name* ends at the target's *job* value on the ``__`` boundary."""
+    if job is None:
+        return True
+    return name == job or name.endswith(f"{KEDRO_DAGSTER_SEPARATOR}{job}")
+
+
+def resolve_target(target: dict[str, str], factories: dict[str, JobOptions]) -> tuple[str, JobOptions] | None:
+    """Render a single target into its ``(name, JobOptions)``, or ``None``.
+
+    Selects the most-specific factory consistent with the target (see module
+    docstring). Returns ``None`` if no factory is consistent with the target.
+    """
+    target_keys = set(target)
+    job = target.get("job")
+
+    candidates: list[tuple[str, JobOptions, str, int, int]] = []
+    for key, config in factories.items():
+        toks = _tokens(key)
+        if not toks <= target_keys:
+            continue
+        name = _render_str(key, target)
+        if "{" in name:  # unfilled placeholder remained
+            continue
+        if not _matches_job_type(name, job):
+            continue
+        candidates.append((key, config, name, _literal_len(key), len(toks)))
+
+    if not candidates:
+        return None
+
+    # The canonical name is set by the most-general candidate (most tokens; ties
+    # broken by most literal characters, then key) so it reflects every token of
+    # the target (e.g. the full product, not a specific factory's literal prefix).
+    canonical = max(candidates, key=lambda c: (c[4], c[3], c[0]))[2]
+    applicable = [c for c in candidates if c[2] == canonical]
+    # Most-specific applicable factory (most literal characters) supplies the body.
+    key, config, name, *_ = max(applicable, key=lambda c: (c[3], c[0]))
+    return name, _render_job(config, target)
+
+
+def enumerate_jobs(config: KedroDagsterConfig, pipelines: Mapping[str, Any] | None = None) -> dict[str, JobOptions]:
+    """Render every derived binding into a ``name -> JobOptions`` map, overlaying literals.
+
+    Bindings are derived from the Kedro pipeline namespaces (see
+    :func:`_derive_bindings`). Literal (non-factory) ``jobs`` entries are included
+    and take precedence over rendered ones on a name collision.
+    """
+    jobs = config.jobs or {}
+    factories = {k: v for k, v in jobs.items() if is_factory(k)}
+    literals = {k: v for k, v in jobs.items() if not is_factory(k)}
+
+    rendered: dict[str, JobOptions] = {}
+    for binding in _derive_bindings(config, pipelines):
+        result = resolve_target(binding, factories)
+        if result is None:  # pragma: no cover - defensive; a derived binding always has its own factory
+            raise ValueError(f"No job factory matches binding {binding!r}.")
+        name, job_config = result
+        if name in rendered:  # pragma: no cover - defensive; bindings are de-duplicated before rendering
+            raise ValueError(f"Two bindings render to the same job name '{name}'.")
+        rendered[name] = job_config
+
+    rendered.update(literals)  # literal jobs win over rendered ones
+    return rendered
+
+
+def resolve_jobs(
+    config: KedroDagsterConfig, job_names: list[str], pipelines: Mapping[str, Any] | None = None
+) -> dict[str, JobOptions]:
+    """Resolve requested job names to ``JobOptions`` via literals + rendered bindings.
+
+    Literal jobs are matched directly; any remaining name is looked up in the
+    enumerated job set (see :func:`enumerate_jobs`). Raises a ``ValueError`` listing
+    available names if a requested name is neither a literal job nor a rendered one.
+
+    Notes
+    -----
+    Dagster's ``Definitions`` enumerates every job up front, so kedro-dagster has
+    no single-job ``run -j <name>`` path; this function is retained for structural
+    parity with the sibling ``kedro-azureml-pipeline`` plugin.
+    """
+    jobs = config.jobs or {}
+    literals = {k: v for k, v in jobs.items() if not is_factory(k)}
+    has_factories = any(is_factory(k) for k in jobs)
+
+    resolved: dict[str, JobOptions] = {}
+    all_jobs: dict[str, JobOptions] | None = None
+    missing: list[str] = []
+    for name in job_names:
+        if name in literals:
+            resolved[name] = literals[name]
+            continue
+        if not has_factories:  # nothing to render; only literal jobs exist
+            missing.append(name)
+            continue
+        if all_jobs is None:
+            all_jobs = enumerate_jobs(config, pipelines)
+        if name in all_jobs:
+            resolved[name] = all_jobs[name]
+        else:
+            missing.append(name)
+
+    if missing:
+        available = sorted(all_jobs if all_jobs is not None else literals)
+        raise ValueError(
+            f"Job(s) not found in config: {', '.join(sorted(missing))}. Available jobs: {', '.join(available)}"
+        )
+    return resolved
+
+
+def expand_job_factories(config: KedroDagsterConfig, pipelines: Mapping[str, Any] | None = None) -> KedroDagsterConfig:
+    """Expand factory ``jobs`` keys into concrete jobs, once, before translation.
+
+    Returns *config* unchanged when it declares no factory keys (expansion is a
+    no-op for the common case). Otherwise returns a copy whose ``jobs`` are the
+    concrete jobs from :func:`enumerate_jobs` (rendered factory jobs plus literal
+    jobs), so every downstream consumer sees only concrete jobs.
+
+    Parameters
+    ----------
+    config : KedroDagsterConfig
+        Parsed Kedro-Dagster configuration, possibly containing factory keys.
+    pipelines : Mapping[str, Any] or None, optional
+        Kedro pipeline registry used to derive bindings. Defaults to the global
+        registry when ``None``.
+
+    Returns
+    -------
+    KedroDagsterConfig
+        Configuration whose ``jobs`` contain no ``{placeholder}`` keys.
+
+    See Also
+    --------
+    `kedro_dagster.factory.enumerate_jobs` :
+        Renders the concrete job set consumed here.
+    `kedro_dagster.translator.KedroProjectTranslator.to_dagster` :
+        Calls this immediately after loading the configuration.
+    """
+    if not any(is_factory(key) for key in (config.jobs or {})):
+        return config
+    return config.model_copy(update={"jobs": enumerate_jobs(config, pipelines)})

--- a/src/kedro_dagster/translator.py
+++ b/src/kedro_dagster/translator.py
@@ -19,6 +19,7 @@ from kedro_dagster.dagster import (
     LoggerCreator,
     ScheduleCreator,
 )
+from kedro_dagster.factory import expand_job_factories
 from kedro_dagster.kedro import KedroRunTranslator
 from kedro_dagster.nodes import NodeTranslator
 from kedro_dagster.pipelines import PipelineTranslator
@@ -220,6 +221,12 @@ class KedroProjectTranslator:
         LOGGER.info("Translating Kedro project into Dagster...")
 
         dagster_config = get_dagster_config(self._context)
+        # Expand any job-factory keys ('{placeholder}' markers) into concrete jobs
+        # once, before any consumer reads dagster_config.jobs. Downstream creators
+        # (pipeline/executor/schedule/sensor) then see only concrete jobs.
+        from kedro.framework.project import pipelines
+
+        dagster_config = expand_job_factories(dagster_config, pipelines)
 
         kedro_run_translator = KedroRunTranslator(
             context=self._context,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import click
 import pytest
@@ -645,3 +646,83 @@ class TestCliListDefs:
         assets = output.get("assets", [])
         asset_keys = [asset.get("asset_key") or asset["key"] for asset in assets]
         assert len(asset_keys) >= 1, f"Expected at least 1 asset, got {asset_keys}"
+
+
+class TestPatternCommands:
+    """Tests for `kedro dagster resolve-patterns` and `list-patterns`."""
+
+    @staticmethod
+    def _patch_loader(monkeypatch, cfg, pipes):
+        """Patch the session-loading helper so no real Kedro project is needed."""
+        from kedro_dagster.cli import functions as fns
+
+        monkeypatch.setattr(fns, "_load_config_and_pipelines", lambda env: (cfg, pipes))
+
+    @staticmethod
+    def _factory_config():
+        from kedro_dagster.config.models import KedroDagsterConfig
+
+        return KedroDagsterConfig.model_validate({
+            "jobs": {
+                "{product}__training": {
+                    "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}"]},
+                    "schedule": "daily",
+                },
+                "nightly": {
+                    "pipeline": {"pipeline_name": "reporting"},
+                    "schedule": {"cron_schedule": "0 0 * * *"},
+                },
+            }
+        })
+
+    @staticmethod
+    def _pipes():
+        return {
+            "training": SimpleNamespace(nodes=[SimpleNamespace(namespace="alpha"), SimpleNamespace(namespace="beta")])
+        }
+
+    def test_resolve_patterns_renders_jobs(self, monkeypatch):
+        """resolve-patterns prints rendered factory jobs and literal jobs with details."""
+        self._patch_loader(monkeypatch, self._factory_config(), self._pipes())
+        result = CliRunner().invoke(cli_dagster, ["resolve-patterns", "-e", "base"])
+        assert result.exit_code == 0, result.output
+        assert "alpha__training" in result.output
+        assert "beta__training" in result.output
+        assert "namespaces=[alpha]" in result.output
+        assert "schedule=daily" in result.output  # string schedule reference
+        assert "nightly" in result.output  # literal job included
+        assert "schedule=0 0 * * *" in result.output  # inline ScheduleOptions
+
+    def test_list_patterns_lists_factory_keys_only(self, monkeypatch):
+        """list-patterns prints factory keys and omits literal jobs."""
+        self._patch_loader(monkeypatch, self._factory_config(), self._pipes())
+        result = CliRunner().invoke(cli_dagster, ["list-patterns", "-e", "base"])
+        assert result.exit_code == 0, result.output
+        assert "{product}__training" in result.output
+        assert "nightly" not in result.output
+
+    def test_resolve_patterns_empty(self, monkeypatch):
+        """resolve-patterns reports an empty state when there are no jobs."""
+        from kedro_dagster.config.models import KedroDagsterConfig
+
+        self._patch_loader(monkeypatch, KedroDagsterConfig(), {})
+        result = CliRunner().invoke(cli_dagster, ["resolve-patterns", "-e", "base"])
+        assert result.exit_code == 0, result.output
+        assert "No jobs resolved" in result.output
+
+    def test_list_patterns_empty(self, monkeypatch):
+        """list-patterns reports an empty state when there are no factory keys."""
+        from kedro_dagster.config.models import KedroDagsterConfig
+
+        self._patch_loader(monkeypatch, KedroDagsterConfig(), {})
+        result = CliRunner().invoke(cli_dagster, ["list-patterns", "-e", "base"])
+        assert result.exit_code == 0, result.output
+        assert "No job factory patterns" in result.output
+
+    def test_load_config_and_pipelines_real_project(self, monkeypatch, kedro_project_no_dagster_config_base):
+        """Exercise _load_config_and_pipelines end-to-end against a real project."""
+        options = kedro_project_no_dagster_config_base
+        monkeypatch.chdir(options.project_path)
+        result = CliRunner().invoke(cli_dagster, ["list-patterns", "-e", "base"])
+        assert result.exit_code == 0, result.output
+        assert "No job factory patterns" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -672,6 +672,7 @@ class TestPatternCommands:
                     "pipeline": {"pipeline_name": "reporting"},
                     "schedule": {"cron_schedule": "0 0 * * *"},
                 },
+                "adhoc": {"pipeline": {"pipeline_name": "adhoc"}},  # no schedule, no namespaces
             }
         })
 
@@ -692,6 +693,7 @@ class TestPatternCommands:
         assert "schedule=daily" in result.output  # string schedule reference
         assert "nightly" in result.output  # literal job included
         assert "schedule=0 0 * * *" in result.output  # inline ScheduleOptions
+        assert "adhoc" in result.output  # literal job with no schedule / no namespaces
 
     def test_list_patterns_lists_factory_keys_only(self, monkeypatch):
         """list-patterns prints factory keys and omits literal jobs."""

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -33,6 +33,7 @@ def _pipe(*namespaces):
 
 
 def _config(jobs):
+    """Build a ``KedroDagsterConfig`` from a raw ``jobs`` mapping."""
     return KedroDagsterConfig.model_validate({"jobs": jobs})
 
 
@@ -42,6 +43,7 @@ def _factories(jobs):
 
 
 def _inference(schedule="da_daily"):
+    """A minimal inference-pipeline factory body with a three-level binding axis."""
     return {
         "schedule": schedule,
         "pipeline": {"pipeline_name": "inference", "node_namespaces": ["{product}.{group}.{variant}"]},
@@ -49,6 +51,7 @@ def _inference(schedule="da_daily"):
 
 
 def _base_jobs():
+    """A representative set of training/inference factories over the ``_NS4`` namespaces."""
     return {
         "{product}__{group}__{variant}__training": {
             "schedule": "weekly_monday",
@@ -66,281 +69,289 @@ DA = {"product": "da_energy", "group": "hub", "variant": "champion", "job": "inf
 RT = {"product": "rt_energy", "group": "hub", "variant": "champion", "job": "inference"}
 
 
-# --- small helpers -----------------------------------------------------------
+class TestHelpers:
+    """Tests for the small factory helper functions."""
 
+    def test_is_factory(self):
+        """A key with ``{placeholder}`` markers is a factory; a plain key is not."""
+        assert is_factory("{product}__{group}__inference")
+        assert not is_factory("snapshot")
 
-def test_is_factory():
-    assert is_factory("{product}__{group}__inference")
-    assert not is_factory("snapshot")
+    def test_job_suffix(self):
+        """The job-type suffix is the literal text after the last ``{token}``."""
+        assert _job_suffix("{product}__{group}__{variant}__inference") == "inference"
+        assert _job_suffix("{product}__data_processing_candidate1") == "data_processing_candidate1"
+        assert _job_suffix("rt_energy__{group}__{variant}__inference") == "inference"
 
-
-def test_job_suffix():
-    assert _job_suffix("{product}__{group}__{variant}__inference") == "inference"
-    assert _job_suffix("{product}__data_processing_candidate1") == "data_processing_candidate1"
-    assert _job_suffix("rt_energy__{group}__{variant}__inference") == "inference"
-
-
-def test_bind_namespace():
-    assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub.champion") == {
-        "product": "da_energy",
-        "group": "hub",
-        "variant": "champion",
-    }
-    assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub") is None  # too shallow
-    assert _bind_namespace("rt_energy.{group}", "rt_energy.hub") == {"group": "hub"}  # literal match
-    assert _bind_namespace("rt_energy.{group}", "da_energy.hub") is None  # literal mismatch
-
-
-def test_render_str_tolerates_unknown_and_passthrough():
-    assert _render_str("plain", {"a": "b"}) == "plain"
-    assert _render_str("{variant}", {"variant": "champion"}) == "champion"
-    assert _render_str("${oc.env:FOO}", {"variant": "x"}) == "${oc.env:FOO}"  # not a {token}
-    assert _render_str("{missing}", {"variant": "x"}) == "{missing}"  # KeyError tolerated
-
-
-def test_render_job_accepts_dict_and_joboptions():
-    job = _render_job({"pipeline": {"pipeline_name": "p", "tags": ["{variant}"]}}, {"variant": "champion"})
-    assert job.pipeline.tags == ["champion"]
-
-
-def test_render_job_passes_through_non_string_leaves():
-    job = _render_job(
-        {"pipeline": {"pipeline_name": "p"}, "schedule": {"cron_schedule": "0 0 * * *", "metadata": {"retries": 3}}},
-        {},
-    )
-    assert job.schedule.metadata["retries"] == 3  # int leaves are passed through unchanged
-
-
-def test_matches_job_type():
-    assert _matches_job_type("x__inference", None) is True  # no job constraint
-    assert _matches_job_type("x__inference", "inference") is True
-    assert _matches_job_type("x__data_science", "data_processing") is False
-    assert _matches_job_type("inference", "inference") is True  # exact
-
-
-# --- resolve_target (the forward engine) -------------------------------------
-
-
-def test_resolve_target_renders_forward():
-    factories = _factories({"{product}__{group}__{variant}__inference": _inference()})
-    name, job = resolve_target(DA, factories)
-    assert name == "da_energy__hub__champion__inference"
-    assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
-
-
-def test_resolve_target_most_specific_wins():
-    factories = _factories({
-        "{product}__{group}__{variant}__inference": _inference("da_daily"),
-        "rt_energy__{group}__{variant}__inference": _inference("rt_hourly"),
-    })
-    _, job = resolve_target(RT, factories)
-    assert job.schedule == "rt_hourly"  # rt factory is more specific
-    _, job = resolve_target(DA, factories)
-    assert job.schedule == "da_daily"  # rt render != canonical -> excluded
-
-
-def test_resolve_target_none_when_no_consistent_factory():
-    factories = _factories({"{product}__{group}__{variant}__training": _inference()})
-    assert resolve_target(DA, factories) is None  # job 'inference' != 'training'
-
-
-def test_resolve_target_skips_factory_with_extra_token():
-    # factory needs {region}, which the binding lacks -> not a candidate
-    factories = _factories({"{product}__{group}__{variant}__{region}__inference": _inference()})
-    assert resolve_target(DA, factories) is None
-
-
-def test_resolve_target_skips_when_render_leaves_a_brace():
-    # a binding value containing a brace leaves an unfilled placeholder
-    factories = _factories({"{product}__{group}__inference": _inference()})
-    assert resolve_target({"product": "da_energy", "group": "{oops}", "job": "inference"}, factories) is None
-
-
-def test_render_job_roundtrips_string_executor_and_inline_schedule():
-    # D3: a real JobOptions instance round-trips through model_dump -> model_validate,
-    # keeping a string executor reference and an inline schedule intact.
-    factories = _factories({
-        "{product}__{group}__{variant}__inference": {
-            "pipeline": {"pipeline_name": "inference", "node_namespaces": ["{product}.{group}.{variant}"]},
-            "executor": "multiprocessing",
-            "schedule": {"cron_schedule": "0 2 * * *"},
-            "loggers": ["console"],
+    def test_bind_namespace(self):
+        """A namespace binds to a template's tokens, honoring literal segments and depth."""
+        assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub.champion") == {
+            "product": "da_energy",
+            "group": "hub",
+            "variant": "champion",
         }
-    })
-    name, job = resolve_target(DA, factories)
-    assert name == "da_energy__hub__champion__inference"
-    assert job.executor == "multiprocessing"  # string executor reference intact
-    assert job.schedule.cron_schedule == "0 2 * * *"  # inline schedule intact
-    assert job.loggers == ["console"]
-    assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
+        assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub") is None  # too shallow
+        assert _bind_namespace("rt_energy.{group}", "rt_energy.hub") == {"group": "hub"}  # literal match
+        assert _bind_namespace("rt_energy.{group}", "da_energy.hub") is None  # literal mismatch
 
+    def test_render_str_tolerates_unknown_and_passthrough(self):
+        """String rendering fills known fields and leaves other syntax untouched."""
+        assert _render_str("plain", {"a": "b"}) == "plain"
+        assert _render_str("{variant}", {"variant": "champion"}) == "champion"
+        assert _render_str("${oc.env:FOO}", {"variant": "x"}) == "${oc.env:FOO}"  # not a {token}
+        assert _render_str("{missing}", {"variant": "x"}) == "{missing}"  # KeyError tolerated
 
-# --- enumerate_jobs (pipeline-derived) ---------------------------------------
+    def test_render_job_accepts_dict_and_joboptions(self):
+        """Rendering interpolates string leaves of a raw dict body."""
+        job = _render_job({"pipeline": {"pipeline_name": "p", "tags": ["{variant}"]}}, {"variant": "champion"})
+        assert job.pipeline.tags == ["champion"]
 
-
-def test_enumerate_derives_one_job_per_namespace():
-    jobs = enumerate_jobs(_config(_base_jobs()), pipelines=_PIPES)
-    assert set(jobs) == {
-        "da_energy__hub__champion__training",
-        "da_energy__hub__challenger__training",
-        "rt_energy__hub__champion__training",
-        "rt_energy__hub__challenger__training",
-        "da_energy__hub__champion__inference",
-        "da_energy__hub__challenger__inference",
-        "rt_energy__hub__champion__inference",
-        "rt_energy__hub__challenger__inference",
-    }
-    assert jobs["da_energy__hub__champion__inference"].schedule == "da_daily"
-    assert jobs["rt_energy__hub__champion__inference"].schedule == "rt_hourly"  # most-specific + dedup
-    assert jobs["da_energy__hub__champion__inference"].pipeline.node_namespaces == ["da_energy.hub.champion"]
-
-
-def test_enumerate_adding_a_namespace_adds_a_job():
-    pipes = {"training": _pipe(*_NS4, "da_energy.zone.champion"), "inference": _pipe(*_NS4)}
-    jobs = enumerate_jobs(_config(_base_jobs()), pipelines=pipes)
-    assert "da_energy__zone__champion__training" in jobs
-    assert jobs["da_energy__zone__champion__training"].pipeline.node_namespaces == ["da_energy.zone.champion"]
-
-
-def test_enumerate_includes_literals_with_precedence():
-    jobs_cfg = {**_base_jobs(), "snapshot": {"pipeline": {"pipeline_name": "snapshot"}}}
-    jobs = enumerate_jobs(_config(jobs_cfg), pipelines=_PIPES)
-    assert jobs["snapshot"].pipeline.pipeline_name == "snapshot"  # literal preserved
-
-
-def test_enumerate_literal_overrides_rendered_name():
-    jobs_cfg = {
-        "{product}__{group}__{variant}__inference": _inference(),
-        "da_energy__hub__champion__inference": {"pipeline": {"pipeline_name": "custom"}},  # literal collision
-    }
-    jobs = enumerate_jobs(_config(jobs_cfg), pipelines={"inference": _pipe("da_energy.hub.champion")})
-    assert jobs["da_energy__hub__champion__inference"].pipeline.pipeline_name == "custom"
-
-
-def test_enumerate_name_token_absent_from_namespaces_raises():
-    cfg = _config({
-        "{product}__{group}__{variant}__{job}": {
-            "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
-        }
-    })
-    with pytest.raises(ValueError, match="absent from its node_namespaces template"):
-        enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")})
-
-
-def test_enumerate_skips_unregistered_pipeline_and_shallow_namespace():
-    cfg = _config({
-        "{product}__{group}__{variant}__ghost": {
-            "pipeline": {"pipeline_name": "ghost", "node_namespaces": ["{product}.{group}.{variant}"]},
-        },
-        "{product}__{group}__{variant}__training": {
-            "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
-        },
-    })
-    pipes = {"training": _pipe("da_energy.hub.champion", "da_energy.shared")}  # 'ghost' absent; 'shared' too shallow
-    jobs = enumerate_jobs(cfg, pipelines=pipes)
-    assert set(jobs) == {"da_energy__hub__champion__training"}
-
-
-def test_enumerate_literal_prefix_template_skips_nonmatching_namespace():
-    cfg = _config({
-        "rt_only__{group}__{variant}__training": {
-            "pipeline": {"pipeline_name": "training", "node_namespaces": ["rt_energy.{group}.{variant}"]},
-        }
-    })
-    pipes = {"training": _pipe("rt_energy.hub.champion", "da_energy.hub.champion")}
-    jobs = enumerate_jobs(cfg, pipelines=pipes)
-    assert set(jobs) == {"rt_only__hub__champion__training"}  # da_energy skipped by literal mismatch
-
-
-def test_enumerate_factory_with_no_node_namespaces_is_skipped():
-    cfg = _config({"{product}__{group}__{variant}__training": {"pipeline": {"pipeline_name": "training"}}})
-    assert enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")}) == {}
-
-
-def test_enumerate_falls_back_to_global_pipelines(monkeypatch):
-    monkeypatch.setattr(
-        "kedro.framework.project.pipelines", {"training": _pipe("da_energy.hub.champion")}, raising=False
-    )
-    cfg = _config({
-        "{product}__{group}__{variant}__training": {
-            "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]}
-        }
-    })
-    jobs = enumerate_jobs(cfg)  # pipelines=None -> global registry
-    assert "da_energy__hub__champion__training" in jobs
-
-
-# --- expand_job_factories (the translation entry point) ----------------------
-
-
-def test_expand_job_factories_example_namespaces():
-    # Mirrors the kedro-dagster-example staging config: data_processing namespaces are
-    # depth-1 ('reviews_predictor'), data_science are depth-2 ('reviews_predictor.candidate1'),
-    # both bound by the depth-1 axis '{product}'.
-    cfg = _config({
-        "{product}__data_processing_candidate1": {
-            "pipeline": {
-                "pipeline_name": "data_processing",
-                "node_namespaces": ["{product}"],
-                "tags": ["candidate1"],
+    def test_render_job_passes_through_non_string_leaves(self):
+        """Non-string leaves (e.g. an int in schedule metadata) survive rendering unchanged."""
+        job = _render_job(
+            {
+                "pipeline": {"pipeline_name": "p"},
+                "schedule": {"cron_schedule": "0 0 * * *", "metadata": {"retries": 3}},
             },
-            "executor": "multiprocessing",
-            "schedule": "daily",
-        },
-        "{product}__data_science_candidate1": {
-            "pipeline": {"pipeline_name": "data_science", "node_namespaces": ["{product}"], "tags": ["candidate1"]},
-            "executor": "sequential",
-            "schedule": "daily",
-        },
-    })
-    pipes = {
-        "data_processing": _pipe("reviews_predictor", "price_predictor"),
-        "data_science": _pipe("reviews_predictor.candidate1", "price_predictor.candidate1"),
-    }
-    expanded = expand_job_factories(cfg, pipes)
-    assert set(expanded.jobs) == {
-        "reviews_predictor__data_processing_candidate1",
-        "price_predictor__data_processing_candidate1",
-        "reviews_predictor__data_science_candidate1",
-        "price_predictor__data_science_candidate1",
-    }
-    # depth-1 axis truncates the 2-level data_science namespace to its product prefix
-    ds_job = expanded.jobs["reviews_predictor__data_science_candidate1"]
-    assert ds_job.pipeline.node_namespaces == ["reviews_predictor"]
-    assert ds_job.executor == "sequential"
-    assert expanded.jobs["price_predictor__data_processing_candidate1"].executor == "multiprocessing"
+            {},
+        )
+        assert job.schedule.metadata["retries"] == 3
+
+    def test_matches_job_type(self):
+        """A rendered name matches a job-type only on the ``__`` boundary (or exactly)."""
+        assert _matches_job_type("x__inference", None) is True  # no job constraint
+        assert _matches_job_type("x__inference", "inference") is True
+        assert _matches_job_type("x__data_science", "data_processing") is False
+        assert _matches_job_type("inference", "inference") is True  # exact
 
 
-def test_expand_job_factories_noop_without_factories():
-    cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
-    assert expand_job_factories(cfg, pipelines={}) is cfg  # unchanged, same object
+class TestResolveTarget:
+    """Tests for the forward rendering engine, :func:`resolve_target`."""
+
+    def test_renders_forward(self):
+        """A binding renders forward into its concrete name and interpolated body."""
+        factories = _factories({"{product}__{group}__{variant}__inference": _inference()})
+        name, job = resolve_target(DA, factories)
+        assert name == "da_energy__hub__champion__inference"
+        assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
+
+    def test_most_specific_wins(self):
+        """The most-specific factory (most literal characters) supplies the body."""
+        factories = _factories({
+            "{product}__{group}__{variant}__inference": _inference("da_daily"),
+            "rt_energy__{group}__{variant}__inference": _inference("rt_hourly"),
+        })
+        _, job = resolve_target(RT, factories)
+        assert job.schedule == "rt_hourly"  # rt factory is more specific
+        _, job = resolve_target(DA, factories)
+        assert job.schedule == "da_daily"  # rt render != canonical -> excluded
+
+    def test_none_when_no_consistent_factory(self):
+        """A binding whose job-type matches no factory resolves to ``None``."""
+        factories = _factories({"{product}__{group}__{variant}__training": _inference()})
+        assert resolve_target(DA, factories) is None  # job 'inference' != 'training'
+
+    def test_skips_factory_with_extra_token(self):
+        """A factory needing a token the binding lacks is not a candidate."""
+        factories = _factories({"{product}__{group}__{variant}__{region}__inference": _inference()})
+        assert resolve_target(DA, factories) is None
+
+    def test_skips_when_render_leaves_a_brace(self):
+        """A binding value containing a brace leaves an unfilled placeholder and is skipped."""
+        factories = _factories({"{product}__{group}__inference": _inference()})
+        assert resolve_target({"product": "da_energy", "group": "{oops}", "job": "inference"}, factories) is None
+
+    def test_roundtrips_string_executor_and_inline_schedule(self):
+        """D3: a JobOptions body round-trips through model_dump/validate keeping refs intact."""
+        factories = _factories({
+            "{product}__{group}__{variant}__inference": {
+                "pipeline": {"pipeline_name": "inference", "node_namespaces": ["{product}.{group}.{variant}"]},
+                "executor": "multiprocessing",
+                "schedule": {"cron_schedule": "0 2 * * *"},
+                "loggers": ["console"],
+            }
+        })
+        name, job = resolve_target(DA, factories)
+        assert name == "da_energy__hub__champion__inference"
+        assert job.executor == "multiprocessing"  # string executor reference intact
+        assert job.schedule.cron_schedule == "0 2 * * *"  # inline schedule intact
+        assert job.loggers == ["console"]
+        assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
 
 
-def test_expand_job_factories_noop_when_jobs_is_none():
-    cfg = KedroDagsterConfig()  # jobs is None
-    assert expand_job_factories(cfg, pipelines={}) is cfg
+class TestEnumerateJobs:
+    """Tests for pipeline-derived enumeration, :func:`enumerate_jobs`."""
+
+    def test_derives_one_job_per_namespace(self):
+        """Each distinct pipeline namespace yields one rendered job per factory."""
+        jobs = enumerate_jobs(_config(_base_jobs()), pipelines=_PIPES)
+        assert set(jobs) == {
+            "da_energy__hub__champion__training",
+            "da_energy__hub__challenger__training",
+            "rt_energy__hub__champion__training",
+            "rt_energy__hub__challenger__training",
+            "da_energy__hub__champion__inference",
+            "da_energy__hub__challenger__inference",
+            "rt_energy__hub__champion__inference",
+            "rt_energy__hub__challenger__inference",
+        }
+        assert jobs["da_energy__hub__champion__inference"].schedule == "da_daily"
+        assert jobs["rt_energy__hub__champion__inference"].schedule == "rt_hourly"  # most-specific + dedup
+        assert jobs["da_energy__hub__champion__inference"].pipeline.node_namespaces == ["da_energy.hub.champion"]
+
+    def test_adding_a_namespace_adds_a_job(self):
+        """A new pipeline namespace produces a new rendered job."""
+        pipes = {"training": _pipe(*_NS4, "da_energy.zone.champion"), "inference": _pipe(*_NS4)}
+        jobs = enumerate_jobs(_config(_base_jobs()), pipelines=pipes)
+        assert "da_energy__zone__champion__training" in jobs
+        assert jobs["da_energy__zone__champion__training"].pipeline.node_namespaces == ["da_energy.zone.champion"]
+
+    def test_includes_literals_with_precedence(self):
+        """Literal (non-factory) jobs are included alongside rendered ones."""
+        jobs_cfg = {**_base_jobs(), "snapshot": {"pipeline": {"pipeline_name": "snapshot"}}}
+        jobs = enumerate_jobs(_config(jobs_cfg), pipelines=_PIPES)
+        assert jobs["snapshot"].pipeline.pipeline_name == "snapshot"  # literal preserved
+
+    def test_literal_overrides_rendered_name(self):
+        """A literal job wins over a rendered job of the same name."""
+        jobs_cfg = {
+            "{product}__{group}__{variant}__inference": _inference(),
+            "da_energy__hub__champion__inference": {"pipeline": {"pipeline_name": "custom"}},  # literal collision
+        }
+        jobs = enumerate_jobs(_config(jobs_cfg), pipelines={"inference": _pipe("da_energy.hub.champion")})
+        assert jobs["da_energy__hub__champion__inference"].pipeline.pipeline_name == "custom"
+
+    def test_name_token_absent_from_namespaces_raises(self):
+        """A factory token absent from the binding axis raises a helpful ``ValueError``."""
+        cfg = _config({
+            "{product}__{group}__{variant}__{job}": {
+                "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
+            }
+        })
+        with pytest.raises(ValueError, match="absent from its node_namespaces template"):
+            enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")})
+
+    def test_skips_unregistered_pipeline_and_shallow_namespace(self):
+        """Factories over absent pipelines and namespaces shallower than the axis are skipped."""
+        cfg = _config({
+            "{product}__{group}__{variant}__ghost": {
+                "pipeline": {"pipeline_name": "ghost", "node_namespaces": ["{product}.{group}.{variant}"]},
+            },
+            "{product}__{group}__{variant}__training": {
+                "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
+            },
+        })
+        pipes = {
+            "training": _pipe("da_energy.hub.champion", "da_energy.shared")
+        }  # 'ghost' absent; 'shared' too shallow
+        jobs = enumerate_jobs(cfg, pipelines=pipes)
+        assert set(jobs) == {"da_energy__hub__champion__training"}
+
+    def test_literal_prefix_template_skips_nonmatching_namespace(self):
+        """A literal segment in the axis restricts which namespaces bind."""
+        cfg = _config({
+            "rt_only__{group}__{variant}__training": {
+                "pipeline": {"pipeline_name": "training", "node_namespaces": ["rt_energy.{group}.{variant}"]},
+            }
+        })
+        pipes = {"training": _pipe("rt_energy.hub.champion", "da_energy.hub.champion")}
+        jobs = enumerate_jobs(cfg, pipelines=pipes)
+        assert set(jobs) == {"rt_only__hub__champion__training"}  # da_energy skipped by literal mismatch
+
+    def test_factory_with_no_node_namespaces_is_skipped(self):
+        """A factory without a ``node_namespaces`` axis derives no jobs."""
+        cfg = _config({"{product}__{group}__{variant}__training": {"pipeline": {"pipeline_name": "training"}}})
+        assert enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")}) == {}
+
+    def test_falls_back_to_global_pipelines(self, monkeypatch):
+        """When ``pipelines`` is ``None`` the global Kedro registry is used."""
+        monkeypatch.setattr(
+            "kedro.framework.project.pipelines", {"training": _pipe("da_energy.hub.champion")}, raising=False
+        )
+        cfg = _config({
+            "{product}__{group}__{variant}__training": {
+                "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]}
+            }
+        })
+        jobs = enumerate_jobs(cfg)  # pipelines=None -> global registry
+        assert "da_energy__hub__champion__training" in jobs
 
 
-# --- resolve_jobs (dormant, kept for parity) ---------------------------------
+class TestExpandJobFactories:
+    """Tests for the translation entry point, :func:`expand_job_factories`."""
+
+    def test_example_namespaces(self):
+        """Mirrors the kedro-dagster-example staging config across mixed-depth namespaces."""
+        cfg = _config({
+            "{product}__data_processing_candidate1": {
+                "pipeline": {
+                    "pipeline_name": "data_processing",
+                    "node_namespaces": ["{product}"],
+                    "tags": ["candidate1"],
+                },
+                "executor": "multiprocessing",
+                "schedule": "daily",
+            },
+            "{product}__data_science_candidate1": {
+                "pipeline": {"pipeline_name": "data_science", "node_namespaces": ["{product}"], "tags": ["candidate1"]},
+                "executor": "sequential",
+                "schedule": "daily",
+            },
+        })
+        pipes = {
+            "data_processing": _pipe("reviews_predictor", "price_predictor"),
+            "data_science": _pipe("reviews_predictor.candidate1", "price_predictor.candidate1"),
+        }
+        expanded = expand_job_factories(cfg, pipes)
+        assert set(expanded.jobs) == {
+            "reviews_predictor__data_processing_candidate1",
+            "price_predictor__data_processing_candidate1",
+            "reviews_predictor__data_science_candidate1",
+            "price_predictor__data_science_candidate1",
+        }
+        # depth-1 axis truncates the 2-level data_science namespace to its product prefix
+        ds_job = expanded.jobs["reviews_predictor__data_science_candidate1"]
+        assert ds_job.pipeline.node_namespaces == ["reviews_predictor"]
+        assert ds_job.executor == "sequential"
+        assert expanded.jobs["price_predictor__data_processing_candidate1"].executor == "multiprocessing"
+
+    def test_noop_without_factories(self):
+        """A config with only literal jobs is returned unchanged (same object)."""
+        cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
+        assert expand_job_factories(cfg, pipelines={}) is cfg
+
+    def test_noop_when_jobs_is_none(self):
+        """A config with no ``jobs`` at all is returned unchanged (same object)."""
+        cfg = KedroDagsterConfig()  # jobs is None
+        assert expand_job_factories(cfg, pipelines={}) is cfg
 
 
-def test_resolve_jobs_by_name():
-    selected = resolve_jobs(_config(_base_jobs()), ["rt_energy__hub__champion__inference"], pipelines=_PIPES)
-    assert list(selected) == ["rt_energy__hub__champion__inference"]
+class TestResolveJobs:
+    """Tests for the dormant single-name lookup, :func:`resolve_jobs`."""
 
+    def test_by_name(self):
+        """A rendered job is resolvable by its concrete name."""
+        selected = resolve_jobs(_config(_base_jobs()), ["rt_energy__hub__champion__inference"], pipelines=_PIPES)
+        assert list(selected) == ["rt_energy__hub__champion__inference"]
 
-def test_resolve_jobs_literal_fast_path():
-    cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
-    assert list(resolve_jobs(cfg, ["snapshot"])) == ["snapshot"]
+    def test_multiple_names_reuse_enumeration(self):
+        """Resolving several rendered names enumerates the job set only once."""
+        names = ["da_energy__hub__champion__inference", "rt_energy__hub__champion__inference"]
+        selected = resolve_jobs(_config(_base_jobs()), names, pipelines=_PIPES)
+        assert set(selected) == set(names)
 
+    def test_literal_fast_path(self):
+        """A literal job is resolved directly without enumerating factories."""
+        cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
+        assert list(resolve_jobs(cfg, ["snapshot"])) == ["snapshot"]
 
-def test_resolve_jobs_miss_lists_available():
-    with pytest.raises(ValueError, match="Job\\(s\\) not found"):
-        resolve_jobs(_config(_base_jobs()), ["nope__x__y__inference"], pipelines=_PIPES)
+    def test_miss_lists_available(self):
+        """An unknown name raises a ``ValueError`` listing the available jobs."""
+        with pytest.raises(ValueError, match="Job\\(s\\) not found"):
+            resolve_jobs(_config(_base_jobs()), ["nope__x__y__inference"], pipelines=_PIPES)
 
-
-def test_resolve_jobs_miss_without_factories():
-    # only literal jobs exist -> the requested name can never be rendered
-    cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
-    with pytest.raises(ValueError, match="Job\\(s\\) not found"):
-        resolve_jobs(cfg, ["ghost"])
+    def test_miss_without_factories(self):
+        """An unknown name with no factories present raises a ``ValueError``."""
+        cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
+        with pytest.raises(ValueError, match="Job\\(s\\) not found"):
+            resolve_jobs(cfg, ["ghost"])

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -24,7 +24,7 @@ from kedro_dagster.factory import (
     resolve_target,
 )
 
-_NS4 = ["da_energy.hub.champion", "da_energy.hub.challenger", "rt_energy.hub.champion", "rt_energy.hub.challenger"]
+_NS4 = ["alpha.hub.champion", "alpha.hub.challenger", "beta.hub.champion", "beta.hub.challenger"]
 
 
 def _pipe(*namespaces):
@@ -42,7 +42,7 @@ def _factories(jobs):
     return {k: v for k, v in _config(jobs).jobs.items() if is_factory(k)}
 
 
-def _inference(schedule="da_daily"):
+def _inference(schedule="alpha_daily"):
     """A minimal inference-pipeline factory body with a three-level binding axis."""
     return {
         "schedule": schedule,
@@ -57,16 +57,16 @@ def _base_jobs():
             "schedule": "weekly_monday",
             "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
         },
-        "{product}__{group}__{variant}__inference": _inference("da_daily"),
-        "rt_energy__{group}__{variant}__inference": _inference("rt_hourly"),
+        "{product}__{group}__{variant}__inference": _inference("alpha_daily"),
+        "beta__{group}__{variant}__inference": _inference("beta_hourly"),
     }
 
 
 _PIPES = {"training": _pipe(*_NS4), "inference": _pipe(*_NS4)}
 
 # A complete binding (incl. job-type) as produced by _derive_bindings.
-DA = {"product": "da_energy", "group": "hub", "variant": "champion", "job": "inference"}
-RT = {"product": "rt_energy", "group": "hub", "variant": "champion", "job": "inference"}
+ALPHA = {"product": "alpha", "group": "hub", "variant": "champion", "job": "inference"}
+BETA = {"product": "beta", "group": "hub", "variant": "champion", "job": "inference"}
 
 
 class TestHelpers:
@@ -81,18 +81,18 @@ class TestHelpers:
         """The job-type suffix is the literal text after the last ``{token}``."""
         assert _job_suffix("{product}__{group}__{variant}__inference") == "inference"
         assert _job_suffix("{product}__data_processing_candidate1") == "data_processing_candidate1"
-        assert _job_suffix("rt_energy__{group}__{variant}__inference") == "inference"
+        assert _job_suffix("beta__{group}__{variant}__inference") == "inference"
 
     def test_bind_namespace(self):
         """A namespace binds to a template's tokens, honoring literal segments and depth."""
-        assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub.champion") == {
-            "product": "da_energy",
+        assert _bind_namespace("{product}.{group}.{variant}", "alpha.hub.champion") == {
+            "product": "alpha",
             "group": "hub",
             "variant": "champion",
         }
-        assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub") is None  # too shallow
-        assert _bind_namespace("rt_energy.{group}", "rt_energy.hub") == {"group": "hub"}  # literal match
-        assert _bind_namespace("rt_energy.{group}", "da_energy.hub") is None  # literal mismatch
+        assert _bind_namespace("{product}.{group}.{variant}", "alpha.hub") is None  # too shallow
+        assert _bind_namespace("beta.{group}", "beta.hub") == {"group": "hub"}  # literal match
+        assert _bind_namespace("beta.{group}", "alpha.hub") is None  # literal mismatch
 
     def test_render_str_tolerates_unknown_and_passthrough(self):
         """String rendering fills known fields and leaves other syntax untouched."""
@@ -131,35 +131,35 @@ class TestResolveTarget:
     def test_renders_forward(self):
         """A binding renders forward into its concrete name and interpolated body."""
         factories = _factories({"{product}__{group}__{variant}__inference": _inference()})
-        name, job = resolve_target(DA, factories)
-        assert name == "da_energy__hub__champion__inference"
-        assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
+        name, job = resolve_target(ALPHA, factories)
+        assert name == "alpha__hub__champion__inference"
+        assert job.pipeline.node_namespaces == ["alpha.hub.champion"]
 
     def test_most_specific_wins(self):
         """The most-specific factory (most literal characters) supplies the body."""
         factories = _factories({
-            "{product}__{group}__{variant}__inference": _inference("da_daily"),
-            "rt_energy__{group}__{variant}__inference": _inference("rt_hourly"),
+            "{product}__{group}__{variant}__inference": _inference("alpha_daily"),
+            "beta__{group}__{variant}__inference": _inference("beta_hourly"),
         })
-        _, job = resolve_target(RT, factories)
-        assert job.schedule == "rt_hourly"  # rt factory is more specific
-        _, job = resolve_target(DA, factories)
-        assert job.schedule == "da_daily"  # rt render != canonical -> excluded
+        _, job = resolve_target(BETA, factories)
+        assert job.schedule == "beta_hourly"  # rt factory is more specific
+        _, job = resolve_target(ALPHA, factories)
+        assert job.schedule == "alpha_daily"  # rt render != canonical -> excluded
 
     def test_none_when_no_consistent_factory(self):
         """A binding whose job-type matches no factory resolves to ``None``."""
         factories = _factories({"{product}__{group}__{variant}__training": _inference()})
-        assert resolve_target(DA, factories) is None  # job 'inference' != 'training'
+        assert resolve_target(ALPHA, factories) is None  # job 'inference' != 'training'
 
     def test_skips_factory_with_extra_token(self):
         """A factory needing a token the binding lacks is not a candidate."""
         factories = _factories({"{product}__{group}__{variant}__{region}__inference": _inference()})
-        assert resolve_target(DA, factories) is None
+        assert resolve_target(ALPHA, factories) is None
 
     def test_skips_when_render_leaves_a_brace(self):
         """A binding value containing a brace leaves an unfilled placeholder and is skipped."""
         factories = _factories({"{product}__{group}__inference": _inference()})
-        assert resolve_target({"product": "da_energy", "group": "{oops}", "job": "inference"}, factories) is None
+        assert resolve_target({"product": "alpha", "group": "{oops}", "job": "inference"}, factories) is None
 
     def test_roundtrips_string_executor_and_inline_schedule(self):
         """D3: a JobOptions body round-trips through model_dump/validate keeping refs intact."""
@@ -171,12 +171,12 @@ class TestResolveTarget:
                 "loggers": ["console"],
             }
         })
-        name, job = resolve_target(DA, factories)
-        assert name == "da_energy__hub__champion__inference"
+        name, job = resolve_target(ALPHA, factories)
+        assert name == "alpha__hub__champion__inference"
         assert job.executor == "multiprocessing"  # string executor reference intact
         assert job.schedule.cron_schedule == "0 2 * * *"  # inline schedule intact
         assert job.loggers == ["console"]
-        assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
+        assert job.pipeline.node_namespaces == ["alpha.hub.champion"]
 
 
 class TestEnumerateJobs:
@@ -186,25 +186,25 @@ class TestEnumerateJobs:
         """Each distinct pipeline namespace yields one rendered job per factory."""
         jobs = enumerate_jobs(_config(_base_jobs()), pipelines=_PIPES)
         assert set(jobs) == {
-            "da_energy__hub__champion__training",
-            "da_energy__hub__challenger__training",
-            "rt_energy__hub__champion__training",
-            "rt_energy__hub__challenger__training",
-            "da_energy__hub__champion__inference",
-            "da_energy__hub__challenger__inference",
-            "rt_energy__hub__champion__inference",
-            "rt_energy__hub__challenger__inference",
+            "alpha__hub__champion__training",
+            "alpha__hub__challenger__training",
+            "beta__hub__champion__training",
+            "beta__hub__challenger__training",
+            "alpha__hub__champion__inference",
+            "alpha__hub__challenger__inference",
+            "beta__hub__champion__inference",
+            "beta__hub__challenger__inference",
         }
-        assert jobs["da_energy__hub__champion__inference"].schedule == "da_daily"
-        assert jobs["rt_energy__hub__champion__inference"].schedule == "rt_hourly"  # most-specific + dedup
-        assert jobs["da_energy__hub__champion__inference"].pipeline.node_namespaces == ["da_energy.hub.champion"]
+        assert jobs["alpha__hub__champion__inference"].schedule == "alpha_daily"
+        assert jobs["beta__hub__champion__inference"].schedule == "beta_hourly"  # most-specific + dedup
+        assert jobs["alpha__hub__champion__inference"].pipeline.node_namespaces == ["alpha.hub.champion"]
 
     def test_adding_a_namespace_adds_a_job(self):
         """A new pipeline namespace produces a new rendered job."""
-        pipes = {"training": _pipe(*_NS4, "da_energy.zone.champion"), "inference": _pipe(*_NS4)}
+        pipes = {"training": _pipe(*_NS4, "alpha.zone.champion"), "inference": _pipe(*_NS4)}
         jobs = enumerate_jobs(_config(_base_jobs()), pipelines=pipes)
-        assert "da_energy__zone__champion__training" in jobs
-        assert jobs["da_energy__zone__champion__training"].pipeline.node_namespaces == ["da_energy.zone.champion"]
+        assert "alpha__zone__champion__training" in jobs
+        assert jobs["alpha__zone__champion__training"].pipeline.node_namespaces == ["alpha.zone.champion"]
 
     def test_includes_literals_with_precedence(self):
         """Literal (non-factory) jobs are included alongside rendered ones."""
@@ -216,10 +216,10 @@ class TestEnumerateJobs:
         """A literal job wins over a rendered job of the same name."""
         jobs_cfg = {
             "{product}__{group}__{variant}__inference": _inference(),
-            "da_energy__hub__champion__inference": {"pipeline": {"pipeline_name": "custom"}},  # literal collision
+            "alpha__hub__champion__inference": {"pipeline": {"pipeline_name": "custom"}},  # literal collision
         }
-        jobs = enumerate_jobs(_config(jobs_cfg), pipelines={"inference": _pipe("da_energy.hub.champion")})
-        assert jobs["da_energy__hub__champion__inference"].pipeline.pipeline_name == "custom"
+        jobs = enumerate_jobs(_config(jobs_cfg), pipelines={"inference": _pipe("alpha.hub.champion")})
+        assert jobs["alpha__hub__champion__inference"].pipeline.pipeline_name == "custom"
 
     def test_name_token_absent_from_namespaces_raises(self):
         """A factory token absent from the binding axis raises a helpful ``ValueError``."""
@@ -229,7 +229,7 @@ class TestEnumerateJobs:
             }
         })
         with pytest.raises(ValueError, match="absent from its node_namespaces template"):
-            enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")})
+            enumerate_jobs(cfg, pipelines={"training": _pipe("alpha.hub.champion")})
 
     def test_skips_unregistered_pipeline_and_shallow_namespace(self):
         """Factories over absent pipelines and namespaces shallower than the axis are skipped."""
@@ -241,32 +241,30 @@ class TestEnumerateJobs:
                 "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
             },
         })
-        pipes = {
-            "training": _pipe("da_energy.hub.champion", "da_energy.shared")
-        }  # 'ghost' absent; 'shared' too shallow
+        pipes = {"training": _pipe("alpha.hub.champion", "alpha.shared")}  # 'ghost' absent; 'shared' too shallow
         jobs = enumerate_jobs(cfg, pipelines=pipes)
-        assert set(jobs) == {"da_energy__hub__champion__training"}
+        assert set(jobs) == {"alpha__hub__champion__training"}
 
     def test_literal_prefix_template_skips_nonmatching_namespace(self):
         """A literal segment in the axis restricts which namespaces bind."""
         cfg = _config({
-            "rt_only__{group}__{variant}__training": {
-                "pipeline": {"pipeline_name": "training", "node_namespaces": ["rt_energy.{group}.{variant}"]},
+            "beta_only__{group}__{variant}__training": {
+                "pipeline": {"pipeline_name": "training", "node_namespaces": ["beta.{group}.{variant}"]},
             }
         })
-        pipes = {"training": _pipe("rt_energy.hub.champion", "da_energy.hub.champion")}
+        pipes = {"training": _pipe("beta.hub.champion", "alpha.hub.champion")}
         jobs = enumerate_jobs(cfg, pipelines=pipes)
-        assert set(jobs) == {"rt_only__hub__champion__training"}  # da_energy skipped by literal mismatch
+        assert set(jobs) == {"beta_only__hub__champion__training"}  # alpha skipped by literal mismatch
 
     def test_factory_with_no_node_namespaces_is_skipped(self):
         """A factory without a ``node_namespaces`` axis derives no jobs."""
         cfg = _config({"{product}__{group}__{variant}__training": {"pipeline": {"pipeline_name": "training"}}})
-        assert enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")}) == {}
+        assert enumerate_jobs(cfg, pipelines={"training": _pipe("alpha.hub.champion")}) == {}
 
     def test_falls_back_to_global_pipelines(self, monkeypatch):
         """When ``pipelines`` is ``None`` the global Kedro registry is used."""
         monkeypatch.setattr(
-            "kedro.framework.project.pipelines", {"training": _pipe("da_energy.hub.champion")}, raising=False
+            "kedro.framework.project.pipelines", {"training": _pipe("alpha.hub.champion")}, raising=False
         )
         cfg = _config({
             "{product}__{group}__{variant}__training": {
@@ -274,7 +272,7 @@ class TestEnumerateJobs:
             }
         })
         jobs = enumerate_jobs(cfg)  # pipelines=None -> global registry
-        assert "da_energy__hub__champion__training" in jobs
+        assert "alpha__hub__champion__training" in jobs
 
 
 class TestExpandJobFactories:
@@ -331,12 +329,12 @@ class TestResolveJobs:
 
     def test_by_name(self):
         """A rendered job is resolvable by its concrete name."""
-        selected = resolve_jobs(_config(_base_jobs()), ["rt_energy__hub__champion__inference"], pipelines=_PIPES)
-        assert list(selected) == ["rt_energy__hub__champion__inference"]
+        selected = resolve_jobs(_config(_base_jobs()), ["beta__hub__champion__inference"], pipelines=_PIPES)
+        assert list(selected) == ["beta__hub__champion__inference"]
 
     def test_multiple_names_reuse_enumeration(self):
         """Resolving several rendered names enumerates the job set only once."""
-        names = ["da_energy__hub__champion__inference", "rt_energy__hub__champion__inference"]
+        names = ["alpha__hub__champion__inference", "beta__hub__champion__inference"]
         selected = resolve_jobs(_config(_base_jobs()), names, pipelines=_PIPES)
         assert set(selected) == set(names)
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,339 @@
+"""Tests for forward-only job factory resolution (pipeline-derived bindings).
+
+Ported from the sibling ``kedro-azureml-pipeline`` plugin, adapted to the
+Kedro-Dagster models and the ``__`` job-type boundary (Dagster names forbid the
+``-`` used there). Stub pipelines are plain objects exposing ``.nodes`` whose
+items expose ``.namespace`` — the only pipeline attributes the factory reads.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from kedro_dagster.config.models import KedroDagsterConfig
+from kedro_dagster.factory import (
+    _bind_namespace,
+    _job_suffix,
+    _matches_job_type,
+    _render_job,
+    _render_str,
+    enumerate_jobs,
+    expand_job_factories,
+    is_factory,
+    resolve_jobs,
+    resolve_target,
+)
+
+_NS4 = ["da_energy.hub.champion", "da_energy.hub.challenger", "rt_energy.hub.champion", "rt_energy.hub.challenger"]
+
+
+def _pipe(*namespaces):
+    """A stand-in Kedro pipeline: an object with ``.nodes``, each with ``.namespace``."""
+    return SimpleNamespace(nodes=[SimpleNamespace(namespace=ns) for ns in namespaces])
+
+
+def _config(jobs):
+    return KedroDagsterConfig.model_validate({"jobs": jobs})
+
+
+def _factories(jobs):
+    """Build a config and return its factory entries as validated JobOptions values."""
+    return {k: v for k, v in _config(jobs).jobs.items() if is_factory(k)}
+
+
+def _inference(schedule="da_daily"):
+    return {
+        "schedule": schedule,
+        "pipeline": {"pipeline_name": "inference", "node_namespaces": ["{product}.{group}.{variant}"]},
+    }
+
+
+def _base_jobs():
+    return {
+        "{product}__{group}__{variant}__training": {
+            "schedule": "weekly_monday",
+            "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
+        },
+        "{product}__{group}__{variant}__inference": _inference("da_daily"),
+        "rt_energy__{group}__{variant}__inference": _inference("rt_hourly"),
+    }
+
+
+_PIPES = {"training": _pipe(*_NS4), "inference": _pipe(*_NS4)}
+
+# A complete binding (incl. job-type) as produced by _derive_bindings.
+DA = {"product": "da_energy", "group": "hub", "variant": "champion", "job": "inference"}
+RT = {"product": "rt_energy", "group": "hub", "variant": "champion", "job": "inference"}
+
+
+# --- small helpers -----------------------------------------------------------
+
+
+def test_is_factory():
+    assert is_factory("{product}__{group}__inference")
+    assert not is_factory("snapshot")
+
+
+def test_job_suffix():
+    assert _job_suffix("{product}__{group}__{variant}__inference") == "inference"
+    assert _job_suffix("{product}__data_processing_candidate1") == "data_processing_candidate1"
+    assert _job_suffix("rt_energy__{group}__{variant}__inference") == "inference"
+
+
+def test_bind_namespace():
+    assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub.champion") == {
+        "product": "da_energy",
+        "group": "hub",
+        "variant": "champion",
+    }
+    assert _bind_namespace("{product}.{group}.{variant}", "da_energy.hub") is None  # too shallow
+    assert _bind_namespace("rt_energy.{group}", "rt_energy.hub") == {"group": "hub"}  # literal match
+    assert _bind_namespace("rt_energy.{group}", "da_energy.hub") is None  # literal mismatch
+
+
+def test_render_str_tolerates_unknown_and_passthrough():
+    assert _render_str("plain", {"a": "b"}) == "plain"
+    assert _render_str("{variant}", {"variant": "champion"}) == "champion"
+    assert _render_str("${oc.env:FOO}", {"variant": "x"}) == "${oc.env:FOO}"  # not a {token}
+    assert _render_str("{missing}", {"variant": "x"}) == "{missing}"  # KeyError tolerated
+
+
+def test_render_job_accepts_dict_and_joboptions():
+    job = _render_job({"pipeline": {"pipeline_name": "p", "tags": ["{variant}"]}}, {"variant": "champion"})
+    assert job.pipeline.tags == ["champion"]
+
+
+def test_render_job_passes_through_non_string_leaves():
+    job = _render_job(
+        {"pipeline": {"pipeline_name": "p"}, "schedule": {"cron_schedule": "0 0 * * *", "metadata": {"retries": 3}}},
+        {},
+    )
+    assert job.schedule.metadata["retries"] == 3  # int leaves are passed through unchanged
+
+
+def test_matches_job_type():
+    assert _matches_job_type("x__inference", None) is True  # no job constraint
+    assert _matches_job_type("x__inference", "inference") is True
+    assert _matches_job_type("x__data_science", "data_processing") is False
+    assert _matches_job_type("inference", "inference") is True  # exact
+
+
+# --- resolve_target (the forward engine) -------------------------------------
+
+
+def test_resolve_target_renders_forward():
+    factories = _factories({"{product}__{group}__{variant}__inference": _inference()})
+    name, job = resolve_target(DA, factories)
+    assert name == "da_energy__hub__champion__inference"
+    assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
+
+
+def test_resolve_target_most_specific_wins():
+    factories = _factories({
+        "{product}__{group}__{variant}__inference": _inference("da_daily"),
+        "rt_energy__{group}__{variant}__inference": _inference("rt_hourly"),
+    })
+    _, job = resolve_target(RT, factories)
+    assert job.schedule == "rt_hourly"  # rt factory is more specific
+    _, job = resolve_target(DA, factories)
+    assert job.schedule == "da_daily"  # rt render != canonical -> excluded
+
+
+def test_resolve_target_none_when_no_consistent_factory():
+    factories = _factories({"{product}__{group}__{variant}__training": _inference()})
+    assert resolve_target(DA, factories) is None  # job 'inference' != 'training'
+
+
+def test_resolve_target_skips_factory_with_extra_token():
+    # factory needs {region}, which the binding lacks -> not a candidate
+    factories = _factories({"{product}__{group}__{variant}__{region}__inference": _inference()})
+    assert resolve_target(DA, factories) is None
+
+
+def test_resolve_target_skips_when_render_leaves_a_brace():
+    # a binding value containing a brace leaves an unfilled placeholder
+    factories = _factories({"{product}__{group}__inference": _inference()})
+    assert resolve_target({"product": "da_energy", "group": "{oops}", "job": "inference"}, factories) is None
+
+
+def test_render_job_roundtrips_string_executor_and_inline_schedule():
+    # D3: a real JobOptions instance round-trips through model_dump -> model_validate,
+    # keeping a string executor reference and an inline schedule intact.
+    factories = _factories({
+        "{product}__{group}__{variant}__inference": {
+            "pipeline": {"pipeline_name": "inference", "node_namespaces": ["{product}.{group}.{variant}"]},
+            "executor": "multiprocessing",
+            "schedule": {"cron_schedule": "0 2 * * *"},
+            "loggers": ["console"],
+        }
+    })
+    name, job = resolve_target(DA, factories)
+    assert name == "da_energy__hub__champion__inference"
+    assert job.executor == "multiprocessing"  # string executor reference intact
+    assert job.schedule.cron_schedule == "0 2 * * *"  # inline schedule intact
+    assert job.loggers == ["console"]
+    assert job.pipeline.node_namespaces == ["da_energy.hub.champion"]
+
+
+# --- enumerate_jobs (pipeline-derived) ---------------------------------------
+
+
+def test_enumerate_derives_one_job_per_namespace():
+    jobs = enumerate_jobs(_config(_base_jobs()), pipelines=_PIPES)
+    assert set(jobs) == {
+        "da_energy__hub__champion__training",
+        "da_energy__hub__challenger__training",
+        "rt_energy__hub__champion__training",
+        "rt_energy__hub__challenger__training",
+        "da_energy__hub__champion__inference",
+        "da_energy__hub__challenger__inference",
+        "rt_energy__hub__champion__inference",
+        "rt_energy__hub__challenger__inference",
+    }
+    assert jobs["da_energy__hub__champion__inference"].schedule == "da_daily"
+    assert jobs["rt_energy__hub__champion__inference"].schedule == "rt_hourly"  # most-specific + dedup
+    assert jobs["da_energy__hub__champion__inference"].pipeline.node_namespaces == ["da_energy.hub.champion"]
+
+
+def test_enumerate_adding_a_namespace_adds_a_job():
+    pipes = {"training": _pipe(*_NS4, "da_energy.zone.champion"), "inference": _pipe(*_NS4)}
+    jobs = enumerate_jobs(_config(_base_jobs()), pipelines=pipes)
+    assert "da_energy__zone__champion__training" in jobs
+    assert jobs["da_energy__zone__champion__training"].pipeline.node_namespaces == ["da_energy.zone.champion"]
+
+
+def test_enumerate_includes_literals_with_precedence():
+    jobs_cfg = {**_base_jobs(), "snapshot": {"pipeline": {"pipeline_name": "snapshot"}}}
+    jobs = enumerate_jobs(_config(jobs_cfg), pipelines=_PIPES)
+    assert jobs["snapshot"].pipeline.pipeline_name == "snapshot"  # literal preserved
+
+
+def test_enumerate_literal_overrides_rendered_name():
+    jobs_cfg = {
+        "{product}__{group}__{variant}__inference": _inference(),
+        "da_energy__hub__champion__inference": {"pipeline": {"pipeline_name": "custom"}},  # literal collision
+    }
+    jobs = enumerate_jobs(_config(jobs_cfg), pipelines={"inference": _pipe("da_energy.hub.champion")})
+    assert jobs["da_energy__hub__champion__inference"].pipeline.pipeline_name == "custom"
+
+
+def test_enumerate_name_token_absent_from_namespaces_raises():
+    cfg = _config({
+        "{product}__{group}__{variant}__{job}": {
+            "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
+        }
+    })
+    with pytest.raises(ValueError, match="absent from its node_namespaces template"):
+        enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")})
+
+
+def test_enumerate_skips_unregistered_pipeline_and_shallow_namespace():
+    cfg = _config({
+        "{product}__{group}__{variant}__ghost": {
+            "pipeline": {"pipeline_name": "ghost", "node_namespaces": ["{product}.{group}.{variant}"]},
+        },
+        "{product}__{group}__{variant}__training": {
+            "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]},
+        },
+    })
+    pipes = {"training": _pipe("da_energy.hub.champion", "da_energy.shared")}  # 'ghost' absent; 'shared' too shallow
+    jobs = enumerate_jobs(cfg, pipelines=pipes)
+    assert set(jobs) == {"da_energy__hub__champion__training"}
+
+
+def test_enumerate_literal_prefix_template_skips_nonmatching_namespace():
+    cfg = _config({
+        "rt_only__{group}__{variant}__training": {
+            "pipeline": {"pipeline_name": "training", "node_namespaces": ["rt_energy.{group}.{variant}"]},
+        }
+    })
+    pipes = {"training": _pipe("rt_energy.hub.champion", "da_energy.hub.champion")}
+    jobs = enumerate_jobs(cfg, pipelines=pipes)
+    assert set(jobs) == {"rt_only__hub__champion__training"}  # da_energy skipped by literal mismatch
+
+
+def test_enumerate_factory_with_no_node_namespaces_is_skipped():
+    cfg = _config({"{product}__{group}__{variant}__training": {"pipeline": {"pipeline_name": "training"}}})
+    assert enumerate_jobs(cfg, pipelines={"training": _pipe("da_energy.hub.champion")}) == {}
+
+
+def test_enumerate_falls_back_to_global_pipelines(monkeypatch):
+    monkeypatch.setattr(
+        "kedro.framework.project.pipelines", {"training": _pipe("da_energy.hub.champion")}, raising=False
+    )
+    cfg = _config({
+        "{product}__{group}__{variant}__training": {
+            "pipeline": {"pipeline_name": "training", "node_namespaces": ["{product}.{group}.{variant}"]}
+        }
+    })
+    jobs = enumerate_jobs(cfg)  # pipelines=None -> global registry
+    assert "da_energy__hub__champion__training" in jobs
+
+
+# --- expand_job_factories (the translation entry point) ----------------------
+
+
+def test_expand_job_factories_example_namespaces():
+    # Mirrors the kedro-dagster-example staging config: data_processing namespaces are
+    # depth-1 ('reviews_predictor'), data_science are depth-2 ('reviews_predictor.candidate1'),
+    # both bound by the depth-1 axis '{product}'.
+    cfg = _config({
+        "{product}__data_processing_candidate1": {
+            "pipeline": {
+                "pipeline_name": "data_processing",
+                "node_namespaces": ["{product}"],
+                "tags": ["candidate1"],
+            },
+            "executor": "multiprocessing",
+            "schedule": "daily",
+        },
+        "{product}__data_science_candidate1": {
+            "pipeline": {"pipeline_name": "data_science", "node_namespaces": ["{product}"], "tags": ["candidate1"]},
+            "executor": "sequential",
+            "schedule": "daily",
+        },
+    })
+    pipes = {
+        "data_processing": _pipe("reviews_predictor", "price_predictor"),
+        "data_science": _pipe("reviews_predictor.candidate1", "price_predictor.candidate1"),
+    }
+    expanded = expand_job_factories(cfg, pipes)
+    assert set(expanded.jobs) == {
+        "reviews_predictor__data_processing_candidate1",
+        "price_predictor__data_processing_candidate1",
+        "reviews_predictor__data_science_candidate1",
+        "price_predictor__data_science_candidate1",
+    }
+    # depth-1 axis truncates the 2-level data_science namespace to its product prefix
+    ds_job = expanded.jobs["reviews_predictor__data_science_candidate1"]
+    assert ds_job.pipeline.node_namespaces == ["reviews_predictor"]
+    assert ds_job.executor == "sequential"
+    assert expanded.jobs["price_predictor__data_processing_candidate1"].executor == "multiprocessing"
+
+
+def test_expand_job_factories_noop_without_factories():
+    cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
+    assert expand_job_factories(cfg, pipelines={}) is cfg  # unchanged, same object
+
+
+def test_expand_job_factories_noop_when_jobs_is_none():
+    cfg = KedroDagsterConfig()  # jobs is None
+    assert expand_job_factories(cfg, pipelines={}) is cfg
+
+
+# --- resolve_jobs (dormant, kept for parity) ---------------------------------
+
+
+def test_resolve_jobs_by_name():
+    selected = resolve_jobs(_config(_base_jobs()), ["rt_energy__hub__champion__inference"], pipelines=_PIPES)
+    assert list(selected) == ["rt_energy__hub__champion__inference"]
+
+
+def test_resolve_jobs_literal_fast_path():
+    cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
+    assert list(resolve_jobs(cfg, ["snapshot"])) == ["snapshot"]
+
+
+def test_resolve_jobs_miss_lists_available():
+    with pytest.raises(ValueError, match="Job\\(s\\) not found"):
+        resolve_jobs(_config(_base_jobs()), ["nope__x__y__inference"], pipelines=_PIPES)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -337,3 +337,10 @@ def test_resolve_jobs_literal_fast_path():
 def test_resolve_jobs_miss_lists_available():
     with pytest.raises(ValueError, match="Job\\(s\\) not found"):
         resolve_jobs(_config(_base_jobs()), ["nope__x__y__inference"], pipelines=_PIPES)
+
+
+def test_resolve_jobs_miss_without_factories():
+    # only literal jobs exist -> the requested name can never be rendered
+    cfg = _config({"snapshot": {"pipeline": {"pipeline_name": "snapshot"}}})
+    with pytest.raises(ValueError, match="Job\\(s\\) not found"):
+        resolve_jobs(cfg, ["ghost"])


### PR DESCRIPTION
## Description

Adds a **job factory**: a `dagster.yml` `jobs:` key containing `{placeholder}` markers whose concrete jobs are derived from the Kedro pipeline node namespaces — the job-level analogue of a Kedro dataset factory. It removes the per-(namespace × pipeline) repetition of hand-written job entries, mirroring the factory in the sibling `kedro-azureml-pipeline` plugin.

```yaml
jobs:
  "{product}__data_processing_candidate1":
    pipeline:
      pipeline_name: data_processing
      node_namespaces: ["{product}"]   # {product} binds to each pipeline namespace
      tags: [candidate1]
    executor: multiprocessing
    schedule: daily
```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

A config with no `{placeholder}` keys behaves exactly as before — expansion is a no-op.

## Motivation and Context

Fixes #121

Factories expand to concrete `JobOptions` **once**, right after `get_dagster_config`, so every downstream consumer (pipeline / executor / schedule / sensor / pipeline-resolution) sees only concrete jobs and is unchanged. Design notes:

- **Forward-only, `__` job-type boundary.** Rendered names must be valid Dagster names (`[A-Za-z0-9_]`, no `-`); placeholder-derived parts use single `_`, the fixed job-type tail is separated by `__` (`KEDRO_DAGSTER_SEPARATOR`) so the boundary is unambiguous even though namespaces/pipeline names contain `_`.
- **Whole-body interpolation.** Tokens are substituted into every string leaf, including references like `executor: "{product}_executor"`.
- **Literal-wins / most-specific precedence**, matching the sibling plugin.
- `resolve_jobs` ports for structural parity but is dormant — Dagster's `Definitions` enumerates every job up front (no `run -j <name>`).

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- **New CLI:** `kedro dagster resolve-patterns` (print rendered jobs) and `list-patterns` (list factory keys) — the analogues of `kedro catalog resolve-patterns` / `list-patterns` — preview expansion without booting Dagster.
- **Example migration lives in a separate repo** (`kedro-dagster-example`): `conf/staging` (2 clean factories) and `conf/prod` (`{product}_executor` interpolation) were migrated; `local`/`dev` stay literal (single-product / would over-generate), demonstrating that literal and factory jobs coexist. That change is not part of this PR.
- Verified end-to-end: `resolve-patterns` reproduces the previous concrete job sets (with the `__` boundary) and a full `to_dagster()` yields matching `named_jobs` + schedules; full suite 360 passed.