### PR TITLE
chore(template): update from python-package-copier v0.27.3 to v0.28.1

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -48,6 +48,7 @@ docs/_notebooks.py                   # build step split out of hooks.py; example
 docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
 docs/javascripts/mathjax.js
 docs/javascripts/readthedocs.js
+docs/material/templates/**                  # mkdocstrings template overrides; thin extends over the shipped _base/
 docs/material/overrides/api-index.html
 docs/material/overrides/api-page.html
 docs/material/overrides/api-submodule.html

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: e2a9246547438c7d13aa10b874af7cffd1e2d17c
+_commit: a5f1a20394a4da2ac910636e6d7fb5367a38acf5
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: a5f1a20394a4da2ac910636e6d7fb5367a38acf5
+_commit: 26fdfd9ed8bb34386f5ef13cc8a00e3bd51cad45
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -836,6 +836,36 @@ def _linkify_see_also(html, prefix):
     return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
 
+def _dedupe_heading_ids(html):
+    """Make repeated heading ids unique, keeping the first occurrence bare.
+
+    A page documenting more than one object -- a curated reference page with
+    several ``:::`` directives -- renders each of them at the same depth, so the
+    section templates give every one of them the same ids: two ``#see-also``,
+    two ``#parameters``. That is invalid HTML and makes the fragment ambiguous.
+
+    The templates cannot prevent it. Each ``:::`` is rendered independently and a
+    template has no way to know another object shares its page. Qualifying every
+    id with the object path would fix it and break every existing deep link into
+    the generated pages, which are single-object and vastly more numerous.
+
+    So the first occurrence keeps the bare id -- preserving those links -- and
+    later ones get a numeric suffix, which is what Python-Markdown's own toc
+    extension does for repeated markdown headings. Pages without duplicates are
+    returned unchanged, so this is inert for the single-object case.
+    """
+    seen = {}
+
+    def _rewrite(match):
+        prefix, hid, suffix = match.group(1), match.group(2), match.group(3)
+        seen[hid] = seen.get(hid, 0) + 1
+        if seen[hid] == 1:
+            return match.group(0)
+        return f"{prefix}{hid}_{seen[hid] - 1}{suffix}"
+
+    return re.sub(r'(<h[1-6][^>]*\sid=")([^"]+)(")', _rewrite, html)
+
+
 def _strip_redundant_section_titles(html):
     """Drop the section title the shipped mkdocstrings template still emits.
 
@@ -939,8 +969,19 @@ def on_page_content(html, page, config, files):
     # instead), so nothing downstream can consume the markup out from under it.
     html = _linkify_see_also(html, _site_root_prefix(page))
 
+    # NOT gated on `pages/api/generated/`. The templates render wherever a `:::`
+    # directive appears, including a curated reference page, so the duplicate
+    # title and the repeated ids appear there too. Gating these to the generated
+    # pages left a curated page showing each section title twice and carrying
+    # ambiguous fragments -- the same "it works where we looked" shape that once
+    # left See Also unlinked on exactly those pages. Both are no-ops on a page
+    # with no mkdocstrings output.
+    html = _strip_redundant_section_titles(html)
+    html = _dedupe_heading_ids(html)
+
+    # Still gated: this one derives the module path from the page's own filename
+    # (`pages/api/generated/{qualified}.md`), so it is meaningless elsewhere.
     if src.startswith("pages/api/generated/"):
-        html = _strip_redundant_section_titles(html)
         html = _add_source_links(html, page, config)
 
     # Keyed on the template a page declares, not on where the page happens to

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -487,22 +487,12 @@ def _get_git_ref():
     return _GIT_REF_CACHE
 
 
-# Numpydoc section types to surface in the TOC.
-_DOC_SECTION_TITLE_SLUGS = {
-    "Parameters": "parameters",
-    "Attributes": "attributes",
-    "Returns": "returns",
-    "Raises": "raises",
-    "Examples": "doc-examples",
-}
-_DETAIL_SECTION_SLUGS = {
-    "note": ("notes", "Notes"),
-    "see-also": ("see-also", "See Also"),
-    "references": ("references", "References"),
-}
-
-
-_SEE_ALSO_BLOCK_RE = re.compile(r'<details\s+class="see-also"[^>]*>.*?</details>', re.DOTALL)
+# The See Also container. This used to be `<details class="see-also">`, emitted by
+# mkdocstrings' shipped admonition template and dissolved later by a restructuring
+# pass -- which is why linkification had to run first. The template now emits a
+# heading plus this div, so there is nothing left to dissolve and no ordering
+# constraint. Keyed on the class the override emits; change one and change both.
+_SEE_ALSO_BLOCK_RE = re.compile(r'<div\s+class="[^"]*doc-admonition-see-also[^"]*"[^>]*>.*?</div>', re.DOTALL)
 # An entry's name sits at the START of its line -- mkdocstrings renders one entry
 # per line inside the paragraph. Anchoring here is what keeps a colon-terminated
 # word in an entry's DESCRIPTION ("Target : Note: see below") from being treated
@@ -790,10 +780,14 @@ def _linkify_glossary_terms(html, page, project_root):
 def _linkify_see_also(html, prefix):
     """Turn the names in a rendered See Also section into links.
 
-    Must run while the ``<details class="see-also">`` container still exists --
-    see the ordering comment in ``on_page_content``.  Unresolvable names are
-    left untouched: a docstring may reference a private helper or a concept,
-    and none of those are build errors.
+    Unresolvable names are left untouched: a docstring may reference a private
+    helper or a concept, and none of those are build errors.
+
+    This no longer has an ordering constraint. It used to have to run before the
+    restructuring pass, which dissolved the container it matches -- and getting
+    that order wrong silently degraded class-level sections while method-level
+    ones kept working. The container is now emitted by the admonition template
+    override and nothing consumes it.
     """
 
     def _process_block(block_match):
@@ -842,289 +836,64 @@ def _linkify_see_also(html, prefix):
     return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
 
-def _make_section_heading(slug, title, level=3):
-    """Build a heading element for an API page section."""
-    return (
-        f'<h{level} id="{slug}" class="doc-section-heading">{title}'
-        f'<a class="headerlink" href="#{slug}" '
-        f'title="Permanent link">&para;</a></h{level}>'
-    )
+def _strip_redundant_section_titles(html):
+    """Drop the section title the shipped mkdocstrings template still emits.
 
+    The docstring templates render every section title as
+    ``<p><span class="doc-section-title">Parameters:</span></p>``, and nothing in
+    the template layer can suppress it -- ``section.title`` falls back to a
+    translated string. Our dispatcher override emits a real heading for the same
+    sections, so without this the page shows each title twice.
 
-def _process_api_page_content(html, page, config):
-    """Convert numpydoc sections to h3 headings under mkdocstrings h2.
-
-    Restructures the rendered HTML produced by mkdocstrings so that
-    Parameters, Attributes, Returns, Raises, Notes, See Also,
-    References, and Source Code become proper ``<h3>`` headings.
-    The Source Code section is kept collapsible and preceded by a
-    link to the source file on GitHub.
-    For class pages a "Methods" heading is inserted before
-    ``doc-children`` and method headings are re-levelled h3 → h5.
-    Finally the page TOC is rebuilt to reflect the new structure.
+    Deliberately narrow: only the titles the dispatcher actually maps are
+    removed. A section it does not map (Yields, Warns, ...) keeps its title and
+    is untouched, so nothing loses its label. That set is the inverse of
+    ``doc_section_slugs`` in
+    ``docs/material/templates/python/material/docstring.html.jinja`` and the two
+    must stay in sync -- adding a heading there without adding its title here
+    renders it twice; the reverse renders it not at all.
     """
-    from mkdocs.structure.toc import AnchorLink
+    titles = "|".join(re.escape(t) for t in ("Parameters", "Attributes", "Returns", "Raises", "Examples"))
+    return re.sub(
+        rf'<p>\s*<span class="doc-section-title">\s*(?:{titles}):?\s*</span>\s*</p>\s*',
+        "",
+        html,
+    )
 
-    is_class_page = bool(re.search(r'<h3\s+id="kedro_dagster\.', html))
 
-    # Locate class-level content region
-    h2_match = re.search(r'<h2\s+id="kedro_dagster\.', html)
-    if not h2_match:
+def _add_source_links(html, page, config):
+    """Insert a "View on GitHub" link after each Source Code heading.
+
+    This is the one part of the old restructuring pass that genuinely cannot move
+    into a template: it needs ``repo_url`` and a git ref, and a mkdocstrings
+    template receives the handler's options, not the mkdocs config. The heading
+    itself IS template-owned (see ``class.html.jinja`` / ``function.html.jinja``);
+    only the link is inserted here.
+
+    Keyed on the heading's id rather than its text, because the text is
+    translatable and the id is the thing we control.
+    """
+    repo_url = config.get("repo_url", "").rstrip("/")
+    if not repo_url:
         return html
-    h2_pos = h2_match.start()
 
-    if is_class_page:
-        boundary_match = re.search(r'<div\s+class="doc doc-children"', html[h2_pos:])
-        boundary_pos = h2_pos + boundary_match.start() if boundary_match else len(html)
-    else:
-        boundary_pos = len(html)
-
-    class_region = html[h2_pos:boundary_pos]
-    sections_found = []  # (id, title) in document order
-
-    # Convert doc-section-title spans to h3 headings
-    def _span_to_h3(m):
-        title = re.sub(r"<[^>]+>", "", m.group(1)).strip().rstrip(":")
-        slug = _DOC_SECTION_TITLE_SLUGS.get(title)
-        if slug:
-            sections_found.append((slug, title))
-            return _make_section_heading(slug, title)
-        return m.group(0)
-
-    new_class_region = re.sub(
-        r"<p>\s*<span\s+class=\"doc-section-title\"[^>]*>(.*?)</span>\s*</p>",
-        _span_to_h3,
-        class_region,
+    # pages/api/generated/{qualified}.md -> package/module.py
+    qualified = page.file.src_path.split("/")[-1].removesuffix(".md")
+    parts = qualified.split(".")
+    if len(parts) < 2:
+        return html
+    module_path = "/".join(parts[:-1])
+    link = (
+        f'<p class="github-source-link">'
+        f'<a href="{repo_url}/blob/{_get_git_ref()}/src/{module_path}.py">View on GitHub</a></p>'
     )
 
-    # Convert <details> sections to h3 heading + unwrapped content
-    for detail_cls, (slug, title) in _DETAIL_SECTION_SLUGS.items():
-        detail_re = re.compile(
-            rf'<details\s+class="{re.escape(detail_cls)}"[^>]*>'
-            rf"\s*<summary>{re.escape(title)}</summary>"
-            rf"(.*?)</details>",
-            re.DOTALL,
-        )
-        m = detail_re.search(new_class_region)
-        if m:
-            heading = _make_section_heading(slug, title)
-            inner = m.group(1).strip()
-            new_class_region = new_class_region[: m.start()] + heading + "\n" + inner + new_class_region[m.end() :]
-            sections_found.append((slug, title))
-
-    # Convert <details class="mkdocstrings-source"> to collapsible Source Code
-    # with a GitHub link preceding the code block
-    src_re = re.compile(
-        r'<details\s+class="mkdocstrings-source"[^>]*>'
-        r"\s*<summary>.*?</summary>"
-        r"(.*?)</details>",
-        re.DOTALL,
+    return re.sub(
+        r'(<h[35][^>]*id="[^"]*source-code"[^>]*>.*?</h[35]>)',
+        lambda m: m.group(1) + link,
+        html,
+        flags=re.DOTALL,
     )
-    src_m = src_re.search(new_class_region)
-    if src_m:
-        heading = _make_section_heading("source-code", "Source Code")
-        inner = src_m.group(1).strip()
-
-        # Build GitHub source link from page path and config
-        github_link = ""
-        repo_url = config.get("repo_url", "").rstrip("/")
-        if repo_url:
-            # Extract qualified name from page source path
-            src_path = page.file.src_path  # pages/api/generated/{qualified}.md
-            qualified = src_path.split("/")[-1].removesuffix(".md")
-            # qualified = package.module.Name → module path = package/module.py
-            parts = qualified.split(".")
-            if len(parts) >= 2:
-                module_path = "/".join(parts[:-1])
-                git_ref = _get_git_ref()
-                github_link = (
-                    f'<p class="github-source-link">'
-                    f'<a href="{repo_url}/blob/{git_ref}/src/{module_path}.py">'
-                    f"View on GitHub</a></p>\n"
-                )
-
-        source_block = (
-            heading
-            + "\n"
-            + github_link
-            + '<details class="source-code-details">\n'
-            + "<summary>Show/Hide source</summary>\n"
-            + inner
-            + "\n"
-            + "</details>"
-        )
-        new_class_region = new_class_region[: src_m.start()] + source_block + new_class_region[src_m.end() :]
-        sections_found.append(("source-code", "Source Code"))
-
-    html = html[:h2_pos] + new_class_region + html[boundary_pos:]
-
-    # Insert "Methods" h3 before doc-children
-    if is_class_page:
-        methods_heading = _make_section_heading("methods", "Methods") + "\n"
-        html = re.sub(
-            r'(<div\s+class="doc doc-children")',
-            methods_heading + r"\1",
-            html,
-            count=1,
-        )
-
-    # Increase method heading levels (h3 -> h4) in doc-children
-    if is_class_page:
-        dc_match = re.search(r'<div\s+class="doc doc-children"', html)
-        if dc_match:
-            before = html[: dc_match.start()]
-            after = html[dc_match.start() :]
-            after = re.sub(r"<h3(\s)", r"<h4\1", after)
-            after = re.sub(r"</h3>", "</h4>", after)
-            html = before + after
-
-    # Process method numpydoc sections and source code in doc-children
-    if is_class_page:
-        dc_match2 = re.search(r'<div\s+class="doc doc-children"', html)
-        if dc_match2:
-            dc_start = dc_match2.start()
-            dc_content = html[dc_start:]
-
-            # Build GitHub link once (same source file for all methods)
-            method_github_link = ""
-            repo_url = config.get("repo_url", "").rstrip("/")
-            if repo_url:
-                _src_path = page.file.src_path
-                _qualified = _src_path.split("/")[-1].removesuffix(".md")
-                _parts = _qualified.split(".")
-                if len(_parts) >= 2:
-                    _module_path = "/".join(_parts[:-1])
-                    _git_ref = _get_git_ref()
-                    method_github_link = (
-                        f'<p class="github-source-link">'
-                        f'<a href="{repo_url}/blob/{_git_ref}/src/{_module_path}.py">'
-                        f"View on GitHub</a></p>\n"
-                    )
-
-            # Find all method headings (h4) with their IDs
-            method_positions = [(m.start(), m.group(1)) for m in re.finditer(r'<h4\s+id="([^"]+)"', dc_content)]
-
-            if method_positions:
-                new_dc = dc_content[: method_positions[0][0]]
-                for idx, (pos, method_id) in enumerate(method_positions):
-                    end_pos = method_positions[idx + 1][0] if idx + 1 < len(method_positions) else len(dc_content)
-                    method_short = method_id.split(".")[-1]
-                    section = dc_content[pos:end_pos]
-
-                    # Convert numpydoc section-title spans to h5 headings
-                    def _method_span_to_h5(m, _ms=method_short):
-                        title = re.sub(r"<[^>]+>", "", m.group(1)).strip().rstrip(":")
-                        base_slug = _DOC_SECTION_TITLE_SLUGS.get(title)
-                        if base_slug:
-                            slug = f"{_ms}-{base_slug}"
-                            return _make_section_heading(slug, title, level=5)
-                        return m.group(0)
-
-                    section = re.sub(
-                        r"<p>\s*<span\s+class=\"doc-section-title\"[^>]*>(.*?)</span>\s*</p>",
-                        _method_span_to_h5,
-                        section,
-                    )
-
-                    # Convert detail sections (Notes, See Also, References) to h6
-                    for detail_cls, (base_slug, title) in _DETAIL_SECTION_SLUGS.items():
-                        _slug = f"{method_short}-{base_slug}"
-                        detail_re_m = re.compile(
-                            rf'<details\s+class="{re.escape(detail_cls)}"[^>]*>'
-                            rf"\s*<summary>{re.escape(title)}</summary>"
-                            rf"(.*?)</details>",
-                            re.DOTALL,
-                        )
-                        dm = detail_re_m.search(section)
-                        if dm:
-                            heading = _make_section_heading(_slug, title, level=5)
-                            inner = dm.group(1).strip()
-                            section = section[: dm.start()] + heading + "\n" + inner + section[dm.end() :]
-
-                    # Convert source code to collapsible block with GitHub link
-                    method_src_re = re.compile(
-                        r'<details\s+class="mkdocstrings-source"[^>]*>'
-                        r"\s*<summary>.*?</summary>"
-                        r"(.*?)</details>",
-                        re.DOTALL,
-                    )
-                    msrc_m = method_src_re.search(section)
-                    if msrc_m:
-                        _slug = f"{method_short}-source-code"
-                        heading = _make_section_heading(_slug, "Source Code", level=5)
-                        inner = msrc_m.group(1).strip()
-                        source_block = (
-                            heading
-                            + "\n"
-                            + method_github_link
-                            + '<details class="source-code-details">\n'
-                            + "<summary>Show/Hide source</summary>\n"
-                            + inner
-                            + "\n"
-                            + "</details>"
-                        )
-                        section = section[: msrc_m.start()] + source_block + section[msrc_m.end() :]
-
-                    new_dc += section
-
-                html = html[:dc_start] + new_dc
-
-    # Rename "Examples" h2 to "Tutorials" h3
-    examples_h2 = re.search(r'<h2 id="examples">.*?</h2>', html, re.DOTALL)
-    if examples_h2:
-        old = examples_h2.group(0)
-        new = (
-            old
-            .replace('<h2 id="examples">', '<h3 id="tutorials">')
-            .replace("</h2>", "</h3>")
-            .replace(">Examples<", ">Tutorials<")
-            .replace("#examples", "#tutorials")
-        )
-        html = html.replace(old, new, 1)
-
-    # Rebuild page.toc
-    old_toc = list(page.toc)
-    if old_toc:
-        h1 = old_toc[0]
-        old_h2s = list(h1.children)
-
-        # The first h2 child is the mkdocstrings class/func heading
-        if old_h2s:
-            main_h2 = old_h2s[0]
-
-        # All sections nest inside the mkdocstrings h2
-        section_children = []
-
-        # Numpydoc + detail + source code sections (level 3)
-        for slug, title in sections_found:
-            section_children.append(AnchorLink(title=title, id=slug, level=3))
-
-        # Methods with individual methods nested underneath (level 3 + 4)
-        if is_class_page:
-            methods_entry = AnchorLink(title="Methods", id="methods", level=3)
-            # Recover method names from the HTML h4 headings
-            dc_match_toc = re.search(r'<div\s+class="doc doc-children"', html)
-            if dc_match_toc:
-                for m_toc in re.finditer(r'<h4[^>]+id="([^"]+)"[^>]*>', html[dc_match_toc.start() :]):
-                    method_id = m_toc.group(1)
-                    method_short = method_id.split(".")[-1]
-                    badge = '<code class="doc-symbol doc-symbol-method"></code> '
-                    methods_entry.children.append(AnchorLink(title=badge + method_short, id=method_id, level=4))
-            section_children.append(methods_entry)
-
-        # Tutorials (level 3)
-        for h2 in old_h2s[1:]:
-            if h2.id in ("examples", "tutorials"):
-                section_children.append(AnchorLink(title="Tutorials", id="tutorials", level=3))
-                break
-
-        if old_h2s:
-            main_h2.children = section_children
-            h1.children = [main_h2]
-        else:
-            h1.children = section_children
-
-    return html
 
 
 def on_config(config):
@@ -1151,7 +920,7 @@ def on_config(config):
 
 
 def on_page_content(html, page, config, files):
-    """Post-process HTML: API page TOC and content restructuring."""
+    """Post-process rendered HTML: See Also links, glossary links, API sidebar."""
     src = page.file.src_path
 
     # Keyed on the markup, not on where the page lives: mkdocstrings emits a See
@@ -1161,17 +930,18 @@ def on_page_content(html, page, config, files):
     # page rendered three entries as plain text while the same names linked fine
     # on the generated pages, which is exactly the shape of "it works where we
     # looked". --strict never sees it: this is our own HTML.
-
+    #
+    # There is no ordering constraint here any more. There used to be: a
+    # restructuring pass dissolved the `<details class="see-also">` container
+    # this linkifier matched, so linkifying afterwards silently did nothing for
+    # class-level sections -- the majority -- while appearing to work for
+    # method-level ones. The container is gone (the templates emit a heading
+    # instead), so nothing downstream can consume the markup out from under it.
     html = _linkify_see_also(html, _site_root_prefix(page))
 
-    # Process generated API member pages (per-class/function detail pages)
     if src.startswith("pages/api/generated/"):
-        # ORDER IS LOAD-BEARING: mkdocstrings emits See Also as a
-        # <details class="see-also"> block, and _process_api_page_content
-        # dissolves that block for class-level docstrings.  Linkifying after it
-        # silently does nothing for class-level See Also sections -- the
-        # majority of them -- while appearing to work for method-level ones.
-        html = _process_api_page_content(html, page, config)
+        html = _strip_redundant_section_titles(html)
+        html = _add_source_links(html, page, config)
 
     # Keyed on the template a page declares, not on where the page happens to
     # live: the index is wherever a project put it. Matching a hardcoded
@@ -1180,8 +950,6 @@ def on_page_content(html, page, config, files):
     if page.meta.get("template") in ("api-index.html", "api-submodule.html"):
         page.meta["module_toc"] = _build_module_toc(config, current_src_path=src, prefix=_site_root_prefix(page))
 
-    # Last: the API restructuring above rewrites whole regions, so linking
-    # before it would have its links discarded with the markup they sat in.
     html = _linkify_glossary_terms(html, page, Path(__file__).parent.parent)
 
     return html

--- a/docs/material/templates/python/material/class.html.jinja
+++ b/docs/material/templates/python/material/class.html.jinja
@@ -1,0 +1,66 @@
+{#- Give a class's Source Code and Methods sections real headings.
+
+Both are anchors today (`#source-code`, `#methods`) that the hooks invented with
+a regex after the `toc` extension had run, which is why `page.toc` had to be
+rebuilt by hand. Emitting them here registers them for the table of contents
+automatically.
+
+`{{ super() }}` is doing the work: this file overrides only the two block
+*openings* and defers the bodies to the shipped template, so nothing upstream is
+copied and upstream fixes keep arriving. Extending `_base/class.html.jinja`
+rather than replacing it is what makes that possible -- the shipped
+`material/class.html.jinja` is a one-line stub over `_base/`, and this file
+takes that stub's place.
+
+The "View on GitHub" link is deliberately NOT here: it needs `repo_url` and a
+git ref, and a mkdocstrings template receives the handler's options, not the
+mkdocs config. The hooks insert it after this heading. That split is stated
+rather than accidental.
+-#}
+{% extends "_base/class.html.jinja" %}
+
+{% block source scoped %}
+  {#- Guarded on the same config the shipped block guards its body with:
+      without this, a project that turns off `show_source` would get a heading
+      introducing nothing. -#}
+  {% if config.show_source %}
+    {% filter heading(
+         3 if heading_level == 2 else 5,
+         id="source-code" if heading_level == 2 else (obj.name ~ "-source-code"),
+         toc_label="Source Code",
+       ) %}
+      <span class="doc-section-heading">Source Code</span>
+    {% endfilter %}
+  {% endif %}
+  {{ super() }}
+{% endblock source %}
+
+{% block children scoped %}
+  {#- Only a class that actually renders members gets a Methods heading; an
+      empty one would introduce nothing and add a dead TOC entry. -#}
+  {% if config.members is not false and obj.members %}
+    {% filter heading(3, id="methods", toc_label="Methods") %}
+      <span class="doc-section-heading">Methods</span>
+    {% endfilter %}
+  {% endif %}
+  {#- Deliberately +2, where the shipped block uses +1.
+
+      The page nests h1 title > h2 class > h3 sections, and "Methods" above is
+      one of those h3 sections. A member must therefore start at h4, so it sits
+      UNDER the heading that introduces it rather than beside it. With the
+      shipped +1 a method renders h3 -- level-equal to "Methods" -- which reads
+      as a sibling and flattens the sidebar.
+
+      This is what the old hooks achieved by regex (`<h3` -> `<h4` inside
+      `doc-children`, then the member's own sections `<h3` -> `<h5`). Setting the
+      level here instead lets mkdocstrings' HeadingShiftingTreeprocessor do the
+      shift, which is the machinery that already exists for exactly this.
+
+      The three lines below are the shipped block's body, copied rather than
+      deferred to `super()`: the level is set *inside* that block, so there is no
+      way to influence it from out here. Copying three lines is the smaller evil
+      -- but it is a copy, so check it on a mkdocstrings bump. -#}
+  {% set root = False %}
+  {% set heading_level = heading_level + 2 %}
+  {% include "children.html.jinja" with context %}
+{% endblock children %}

--- a/docs/material/templates/python/material/class.html.jinja
+++ b/docs/material/templates/python/material/class.html.jinja
@@ -36,9 +36,29 @@ rather than accidental.
 {% endblock source %}
 
 {% block children scoped %}
-  {#- Only a class that actually renders members gets a Methods heading; an
-      empty one would introduce nothing and add a dead TOC entry. -#}
-  {% if config.members is not false and obj.members %}
+  {#- Only a class that actually renders methods gets a Methods heading.
+
+      `obj.members` is the WRONG set to test and was the first guard here: it is
+      the pre-filter membership and counts attributes, so every attributes-only
+      class -- a pydantic config model, an Enum, a dataclass -- got a heading
+      introducing nothing plus a dead ToC entry. Measured at 12 of 25 class pages
+      in one repo before this was fixed. `--strict` cannot see it: the anchor
+      resolves, it just leads nowhere.
+
+      This mirrors what `children.html.jinja` actually renders: functions after
+      `filter_objects`, minus `__init__` when it is merged into the class. A
+      namespace is needed because a `{% set %}` inside `{% if %}` is scoped to
+      the branch and would not update the outer name. -#}
+  {% set _ns = namespace(methods=obj.functions|filter_objects(
+       filters=config.filters,
+       members_list=none,
+       inherited_members=config.inherited_members,
+       keep_no_docstrings=config.show_if_no_docstring,
+     )|list) %}
+  {% if config.merge_init_into_class %}
+    {% set _ns.methods = _ns.methods|rejectattr("name", "equalto", "__init__")|list %}
+  {% endif %}
+  {% if config.members is not false and _ns.methods %}
     {% filter heading(3, id="methods", toc_label="Methods") %}
       <span class="doc-section-heading">Methods</span>
     {% endfilter %}

--- a/docs/material/templates/python/material/docstring.html.jinja
+++ b/docs/material/templates/python/material/docstring.html.jinja
@@ -1,0 +1,102 @@
+{#- Emit a real heading before each docstring section this project surfaces.
+
+This overrides mkdocstrings' section *dispatcher*, not the section templates
+themselves. That distinction is the whole design:
+
+  - A section's title lives INSIDE its style block (`table_style` and friends),
+    so overriding `parameters.html.jinja` to change one line means copying its
+    57-line table. Across the eight table-style templates that is ~271 lines of
+    forked upstream markup -- more than the regex pass it replaces, and it stops
+    receiving upstream fixes silently.
+  - Emitting the heading here instead leaves all nine section templates
+    untouched, so they keep getting upstream fixes.
+
+A heading emitted with the `heading` filter is registered for the table of
+contents by mkdocstrings itself (`mkdocstrings_headings_list` records it,
+`get_headings()` hands it to the outer layer, `_HeadingsPostProcessor` removes
+the duplicate). That is why this file exists at all: the hooks used to invent
+these headings with a regex AFTER the `toc` extension had run, so nothing could
+see them, and `page.toc` had to be rebuilt by hand with `AnchorLink` objects.
+Emit them here and that whole apparatus is unnecessary.
+
+Only the sections listed below get headings. That set is not arbitrary -- it
+mirrors exactly what the hooks used to surface, so the page's anchor set is
+unchanged. Adding a kind here ADDS an anchor, which is a URL, so treat it as a
+breaking link change rather than a tidy-up.
+
+The shipped section template still writes its own
+`<p><span class="doc-section-title">...</span></p>`; nothing in the template
+layer can suppress it (`section.title` falls back to a translated string). The
+hooks strip exactly the titles named here -- the inverse of this map, and the
+reason the two must stay in sync.
+-#}
+{% set doc_section_slugs = {
+     "parameters": ("parameters", "Parameters"),
+     "attributes": ("attributes", "Attributes"),
+     "returns": ("returns", "Returns"),
+     "raises": ("raises", "Raises"),
+     "examples": ("doc-examples", "Examples"),
+   } %}
+{% set admonition_slugs = {
+     "note": ("notes", "Notes"),
+     "see-also": ("see-also", "See Also"),
+     "references": ("references", "References"),
+   } %}
+{% if docstring_sections %}
+  {% block logs scoped %}
+    {{ log.debug("Rendering docstring") }}
+  {% endblock logs %}
+  {% with autoref_hook = AutorefsHook(obj, config) %}
+    {% for section in docstring_sections %}
+      {#- The page's own object renders at heading_level 2, its members deeper.
+          Class-level sections are bare (`#parameters`); a member's are prefixed
+          with its name (`#greet-parameters`), which is the scheme the hooks
+          built by string concatenation. -#}
+      {%- set at_root = heading_level == 2 -%}
+      {%- if section.kind.value == "admonition" -%}
+        {%- set mapped = admonition_slugs.get(section.value.kind) -%}
+      {%- else -%}
+        {%- set mapped = doc_section_slugs.get(section.kind.value) -%}
+      {%- endif -%}
+      {%- if mapped -%}
+        {%- set section_id = mapped[0] if at_root else (obj.name ~ "-" ~ mapped[0]) -%}
+        {% filter heading(3 if at_root else 5, id=section_id, toc_label=mapped[1]) %}
+          <span class="doc-section-heading">{{ mapped[1] }}</span>
+        {% endfilter %}
+      {%- endif -%}
+      {% if config.show_docstring_description and section.kind.value == "text" %}
+        {{ section.value|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+      {% elif config.show_docstring_attributes and section.kind.value == "attributes" %}
+        {% include "docstring/attributes.html.jinja" with context %}
+      {% elif config.show_docstring_functions and section.kind.value == "functions" %}
+        {% include "docstring/functions.html.jinja" with context %}
+      {% elif config.show_docstring_classes and section.kind.value == "classes" %}
+        {% include "docstring/classes.html.jinja" with context %}
+      {% elif config.show_docstring_type_aliases and section.kind.value == "type aliases" %}
+        {% include "docstring/type_aliases.html.jinja" with context %}
+      {% elif config.show_docstring_modules and section.kind.value == "modules" %}
+        {% include "docstring/modules.html.jinja" with context %}
+      {% elif config.show_docstring_type_parameters and section.kind.value == "type parameters" %}
+        {% include "docstring/type_parameters.html.jinja" with context %}
+      {% elif config.show_docstring_parameters and section.kind.value == "parameters" %}
+        {% include "docstring/parameters.html.jinja" with context %}
+      {% elif config.show_docstring_other_parameters and section.kind.value == "other parameters" %}
+        {% include "docstring/other_parameters.html.jinja" with context %}
+      {% elif config.show_docstring_raises and section.kind.value == "raises" %}
+        {% include "docstring/raises.html.jinja" with context %}
+      {% elif config.show_docstring_warns and section.kind.value == "warns" %}
+        {% include "docstring/warns.html.jinja" with context %}
+      {% elif config.show_docstring_yields and section.kind.value == "yields" %}
+        {% include "docstring/yields.html.jinja" with context %}
+      {% elif config.show_docstring_receives and section.kind.value == "receives" %}
+        {% include "docstring/receives.html.jinja" with context %}
+      {% elif config.show_docstring_returns and section.kind.value == "returns" %}
+        {% include "docstring/returns.html.jinja" with context %}
+      {% elif config.show_docstring_examples and section.kind.value == "examples" %}
+        {% include "docstring/examples.html.jinja" with context %}
+      {% elif config.show_docstring_description and section.kind.value == "admonition" %}
+        {% include "docstring/admonition.html.jinja" with context %}
+      {% endif %}
+    {% endfor %}
+  {% endwith %}
+{% endif %}

--- a/docs/material/templates/python/material/docstring/admonition.html.jinja
+++ b/docs/material/templates/python/material/docstring/admonition.html.jinja
@@ -1,0 +1,26 @@
+{#- Render a docstring admonition as plain content, not a collapsible block.
+
+The shipped template wraps every admonition in
+`<details class="{{ section.value.kind }}" open>`. That one element is what the
+hooks' `_SEE_ALSO_BLOCK_RE` existed to find, and dissolving it was what forced
+`_linkify_see_also` to run BEFORE the restructuring pass -- an ordering the
+hooks called out as load-bearing, where getting it wrong silently degraded
+class-level See Also sections (the majority) while method-level ones kept
+working. Emitting the content directly removes the container, and with it the
+ordering constraint.
+
+The heading comes from the dispatcher (`docstring.html.jinja`), which is also
+what registers it for the table of contents. Kinds the dispatcher does not map
+still render their title here, so nothing loses its label.
+-#}
+{% block logs scoped %}
+  {{ log.debug("Rendering admonition") }}
+{% endblock logs %}
+
+{% set _mapped_kinds = ["note", "see-also", "references"] %}
+{% if section.value.kind not in _mapped_kinds %}
+  <p><span class="doc-section-title">{{ section.title|convert_markdown(heading_level, html_id, strip_paragraph=True, autoref_hook=autoref_hook) }}</span></p>
+{% endif %}
+<div class="doc-section-item doc-admonition-{{ section.value.kind }}">
+  {{ section.value.contents|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+</div>

--- a/docs/material/templates/python/material/function.html.jinja
+++ b/docs/material/templates/python/material/function.html.jinja
@@ -1,0 +1,25 @@
+{#- Give a function's Source Code section a real heading.
+
+Same reasoning as `class.html.jinja`: the anchor exists today (`#source-code` on
+a function page, `#<method>-source-code` for a class member) but was invented by
+a regex after `toc` had run, so it never reached the table of contents on its
+own. `{{ super() }}` defers the block body to the shipped template.
+
+A function rendered as a class member arrives here with a deeper
+`heading_level`, which is what selects the prefixed id -- the same rule the
+hooks applied by string concatenation.
+-#}
+{% extends "_base/function.html.jinja" %}
+
+{% block source scoped %}
+  {% if config.show_source %}
+    {% filter heading(
+         3 if heading_level == 2 else 5,
+         id="source-code" if heading_level == 2 else (obj.name ~ "-source-code"),
+         toc_label="Source Code",
+       ) %}
+      <span class="doc-section-heading">Source Code</span>
+    {% endfilter %}
+  {% endif %}
+  {{ super() }}
+{% endblock source %}

--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -370,8 +370,19 @@ div.dt-container .dt-paging .dt-paging-button.disabled:active {
   color: var(--md-accent-fg-color);
 }
 
-/* Override Material h5 styling for API doc section headings */
-h5.doc-section-heading {
+/* Override Material's h5 styling for API doc section headings.
+ *
+ * A DESCENDANT selector, not `h5.doc-section-heading`. The class used to sit on
+ * the heading itself, when a hook synthesised the element; the templates that
+ * replaced it wrap the text in `<h5 id="..."><span class="doc-section-heading">`,
+ * so the old selector matched nothing and Material's default
+ * `.md-typeset h5 {text-transform: uppercase; font-size: .8em}` reasserted on
+ * every method-level section heading -- 40 of them on two pages in one repo,
+ * with a green build and no warning, because CSS that matches nothing is silent.
+ *
+ * Both forms are matched so this does not depend on where the class lands. */
+h5.doc-section-heading,
+h5 .doc-section-heading {
   text-transform: none;
   font-size: 1em;
   color: var(--md-default-fg-color);

--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -377,14 +377,20 @@ h5.doc-section-heading {
   color: var(--md-default-fg-color);
 }
 
-/* Collapsible source code details */
-.source-code-details {
+/* Collapsible source code block.
+ *
+ * Keyed on mkdocstrings' own `.mkdocstrings-source`, not a class of ours. The
+ * hooks used to rewrite that element into `<details class="source-code-details">`;
+ * the templates now leave mkdocstrings' markup alone, so the selector follows it.
+ * A stale selector here is invisible -- the page renders unstyled and the build
+ * stays green -- so this moved in the same commit as the markup. */
+.mkdocstrings-source {
   margin: 0.5em 0 1em;
   border: 0.05rem solid var(--md-typeset-table-color);
   border-radius: 0.2rem;
 }
 
-.source-code-details > summary {
+.mkdocstrings-source > summary {
   display: block;
   padding: 0.5em 0.8em;
   font-size: 0.72rem;
@@ -397,27 +403,27 @@ h5.doc-section-heading {
   list-style: none;
 }
 
-.source-code-details > summary::before {
+.mkdocstrings-source > summary::before {
   content: "\25B6\FE0E";   /* right-pointing triangle */
   display: inline-block;
   margin-right: 0.4em;
   transition: transform 0.2s;
 }
 
-.source-code-details[open] > summary::before {
+.mkdocstrings-source[open] > summary::before {
   transform: rotate(90deg);
 }
 
-.source-code-details > summary::-webkit-details-marker {
+.mkdocstrings-source > summary::-webkit-details-marker {
   display: none;
 }
 
-.source-code-details > summary:hover {
+.mkdocstrings-source > summary:hover {
   color: var(--md-accent-fg-color);
   background: var(--md-default-bg-color--lightest);
 }
 
-.source-code-details pre {
+.mkdocstrings-source pre {
   margin: 0 !important;
   border-radius: 0 0 0.2rem 0.2rem;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,14 @@ exclude_docs: |
   # four modules instead of one, which is what made it visible.
   *.py
   __pycache__/
+  # Same reason, one directory over: `docs/material/templates/` holds
+  # mkdocstrings template overrides, which are build tooling, not pages. Without
+  # this they are published as static assets -- confirmed live, `class.html.jinja`
+  # served 200 from the docs site. `material/overrides/*.html` leaks the same way
+  # and is excluded here too; `api-submodule.html` above was the one instance of
+  # this that had been noticed before, handled one file at a time.
+  *.jinja
+  material/overrides/*.html
 
 not_in_nav: |
   assets/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,14 @@ markdown_extensions:
   - sane_lists
   - toc:
       permalink: true
+      # API member pages carry two levels of section heading: the class's own
+      # (h3) and each method's (h5). Only the first belongs in the table of
+      # contents -- listing every method's Parameters/Returns/Source Code turns a
+      # class page's ToC into a wall. The hooks used to get this by building
+      # `page.toc` by hand and simply not adding them; now that the headings are
+      # real, `toc_depth` is what draws the same line. The h5 anchors still
+      # exist and are still linkable -- this only controls what the sidebar lists.
+      toc_depth: 4
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem:
@@ -152,6 +160,15 @@ plugins:
       shadow: true
       manual: false
   - mkdocstrings:
+      custom_templates: docs/material/templates
+      # Overrides live in docs/material/templates/python/material/. Each one is a
+      # thin `{% extends %}` over the shipped `_base/` template, so upstream
+      # fixes keep arriving -- see the header comments in those files for why the
+      # dispatcher is overridden rather than the nine section templates.
+      #
+      # NOTE: this is a PLUGIN-level key, not a handler option. Putting it under
+      # `handlers.python.options` fails the build with
+      # `PythonOptions.__init__() got an unexpected keyword argument`.
       handlers:
         python:
           paths: [src]


### PR DESCRIPTION
Updates the project from python-package-copier **v0.27.3** (`e2a9246`) to **v0.28.1** (`26fdfd9`),
in two commits: the original v0.28.0 update, plus the v0.28.1 fixes folded in.

v0.28.0 replaced `_process_api_page_content` — 283 lines of regex over mkdocstrings' rendered
HTML — and the hand-built `page.toc`/`AnchorLink` rebuild with four thin `{% extends %}`
overrides. `docs/hooks.py` drops **1477 -> 995 lines** and no longer imports mkdocs at all.

The fan-out of v0.28.0 across the fleet found five defects in it. **v0.28.1 fixes all five**,
and this PR now carries the fixed version rather than the workaround.

| File | Change |
|---|---|
| `docs/material/templates/` | **new** — 4 mkdocstrings template overrides |
| `docs/hooks.py` | -376 lines net; regex post-processing and manual ToC removed; `_dedupe_heading_ids` added |
| `docs/stylesheets/theme.css` | `.source-code-details` -> `.mkdocstrings-source`; section-heading selector fixed |
| `mkdocs.yml` | `toc_depth: 4`, plugin-level `custom_templates:`, `exclude_docs` additions |

Zero `.rej` on either update. Whole-tree diff against a pre-update snapshot is exactly the
expected set. `docs/hooks.py`, `theme.css` and all 4 overrides are **byte-identical to a fresh
`copier copy --vcs-ref v0.28.1`**, carrying no local modification.

## The five v0.28.1 fixes, measured here

**1. EOF.** The rendered overrides used to gain a trailing blank line that `end-of-file-fixer`
stripped on every run — a permanent recurring delta in every generated project. The sources now
close with `{%- endraw %}`. Verified on the *rendered* files, not the sources: **0 of 155 tracked
text files end in a blank line**, and the four overrides match the pristine render byte for byte.
Falsified the check by injecting a blank line into `class.html.jinja` — the hook caught and fixed
it — so "Passed" here is real signal rather than a hook that never looks at these files.

**2. `exclude_docs`** gained `*.jinja` and `material/overrides/*.html`. Before: **4 `.jinja` and
3 `.html` served** from `site/material/`. After: **0 `.jinja`, and `site/material/` does not
exist**.

**3. Methods guard.** It tested `obj.members` — the *pre-filter* set, which counts attributes —
so every attributes-only class got a heading introducing nothing plus a dead ToC entry. It now
applies `filter_objects` to `obj.functions`. This repo has the fleet's largest class surface and
a config layer full of attributes-only pydantic models, so it has the most to lose here.
Swept **all 29 class pages, both directions**:

- **14 lost `#methods`** — every one renders **0** methods. All are options/config models
  (`JobOptions`, `K8sJobConfig`, the executor-options family) plus `DagsterCodeLocation` and
  `CliContext`.
- **14 kept `#methods`** — every one renders **>= 1** method (1 to 7 each).
- **0 gained**, and no page kept a heading over nothing.

Method counts were cross-checked by two independent measures (marker headings vs `div.doc-function`
containers); they agree exactly on all 14. An earlier version of my checker unioned the two and
double-counted every method — the direction was unaffected but the numbers were wrong, so they
are reported from the corrected counter.

**4. Duplicate heading ids.** `_dedupe_heading_ids` added; `_strip_redundant_section_titles`
ungated from `pages/api/generated/`. Before: **11 duplicate ids across 2 pages** and **8 leftover
`doc-section-title` spans**. After: **0 and 0**.

**5. CSS.** `theme.css` matched `h5.doc-section-heading`, but the class moved to an inner span
when the templates replaced the hook-synthesised heading, so it matched nothing and Material's
uppercase default reasserted silently. Measured in the built HTML: **0** elements match
`h5.doc-section-heading`, **110** match `h5 .doc-section-heading`. The shipped `theme.css` now
carries both forms, so it matches the shape that actually exists.

## Anchor parity

Every heading `id` recorded with its level and document order, before and after, scoped to
`<article>`. **761 -> 745, and every one of the 16 is accounted for:**

- **-25 removed / +9 added.**
- 16 removals are fix 3 stripping empty `#methods` (13 pages x1, plus `InProcessExecutorOptions`
  which had it x3).
- 9 removals + 9 additions are fix 4 renaming the duplicates on `pages/reference/datasets`
  (`parameters` -> `parameters_1`, and so on for `see-also`, `source-code`, `methods`,
  `doc-examples`, `load-returns`, `load-source-code`, `save-parameters`, `save-source-code`).

No unexplained delta. **See Also anchors: 75 before, 75 after** — none lost, one renamed.

**See Also: 75 sections, 147 entries, 0 unlinked.** The auditor is shape-agnostic (heading + `ul`,
heading + `p`, and surviving containers) and aborts on a zero population rather than reporting a
false all-clear. Note this counts more sections than the v0.28.0 audit in this PR's earlier
revision did (75 vs 62); the population changed shape in v0.28.0 and the two counters disagree on
what a "region" is. The invariant that matters — **0 unlinked** — holds under both.

## CI-critical config survived

Verified from **parsed YAML**, not grep:

- `docstring_options: {warn_unknown_params: false}` — **present** (worth 77 griffe warnings here,
  and now a failing build)
- snippets `base_path` — **`["docs", "."]`** (it includes repo-root-relative
  `src/kedro_dagster/templates/*`; narrowing it to `["docs"]` breaks the build)
- nav — **25 leaves**, per-section `root 1 / Tutorials 4 / How-to 9 / Explanation 5 / Reference 6`,
  **identical leaf-by-leaf**. `mkdocs.yml` received only the 8-line `exclude_docs` addition;
  no nav clobber.

## Other invariants

- `git diff --stat -- docs/assets` — **empty**; all 25 files sha256-identical
- `.github/workflows/` — **byte-identical** (recursive diff); `test-versions` job in `nightly.yml`
  and its `needs: [test, test-versions]` intact, `tests-versions.yml` untouched
- `nox -s check_docs` — **0 warnings** (`mkdocs build --clean --strict`)
- `site/` free of `*.py`, `__pycache__/`, and now `*.jinja`
- `prek run --all-files` — all 14 hooks pass
