### PR TITLE
chore(template): update from python-package-copier v0.28.3 to v0.28.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: c3f6fcf8b6f2ce00e96ae5b918cff755cda0a545
+_commit: d6d0e8260d71339ffe46610d42b2ee4e5061ca93
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 git clone <repo-url>
 cd <project-dir>
 uv sync --group dev
-uv run prek install
+uv run prek install -f
 just test-fast
 ```
 

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -35,7 +35,7 @@ uv sync --group dev
 4. Install the git hooks (required):
 
 ```bash
-uv run prek install
+uv run prek install -f
 ```
 
 ## Development Workflow

--- a/justfile
+++ b/justfile
@@ -7,7 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    uv run prek install
+    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
+    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
+    # every commit. `-f` overwrites instead. Measured; the migration notice
+    # prek prints names this flag, and this is the command people actually run.
+    uv run prek install -f
 
 # Run tests and doctests with parallel execution
 test:


### PR DESCRIPTION
Updates the Copier template from **v0.28.3** (`c3f6fcf`) to **v0.28.4** (`d6d0e82`), on top
of #132.

Makes `just install` self-healing. Without `-f`, prek finds a pre-v0.27.0 pre-commit shim,
moves it to `.git/hooks/pre-commit.legacy` and **chains** it — both hooks then run on every
commit. `-f` overwrites instead. `just install` is the command people already run, so the
routine path repairs itself.

## What changed

Documentation and tooling only — no source, no config, no dependency change. Checked against
a pristine `copier copy` diff of the two refs, taken for this repo's own answers
(`include_examples: False`) before the update ran: exactly 3 files + `.copier-answers.yml`.

| file | change |
|---|---|
| `justfile` | `uv run prek install` → `uv run prek install -f`, plus a 4-line comment |
| `CONTRIBUTING.md` | same one-line change |
| `docs/pages/how-to/contribute.md` | same one-line change |

All three carry `-f` after the update, and each whole-file diff is the template change and
nothing else. `CONTRIBUTING.md` and `contribute.md` are byte-identical to pristine v0.28.4.

`pyproject.toml` — the file that conflicted on both previous updates — is not in this
release and was not touched.

## Local `justfile` customisation survived

Worth recording, because the pre-dispatch measurement had this repo's `justfile` as
byte-matching pristine. It does **not**: the `lint` recipe is locally customised.

```
-    uv run --locked ty check src
+    uv run --extra mlflow --locked ty check --exit-zero-on-warning src
```

It sits ~30 lines below the `install` recipe the `-f` hunk edits, so the two did not share a
hunk and the local line survived — verified in the committed tree, not just the working
copy. After the update the `justfile` differs from pristine v0.28.4 by **exactly that one
line** and nothing else.

The same `--extra mlflow` customisation exists in `.pre-commit-config.yaml`, which this
release does not touch; it is unchanged and still diverges from pristine in the same way.

A sweep for any remaining `prek install` without `-f` across all tracked files returns one
hit, in a **comment** in `.pre-commit-config.yaml` that names the subcommand in prose rather
than issuing it. That line is identical to pristine v0.28.4, so it is not a missed
occurrence.

## Verified unchanged

- **Symbol set unchanged at 58** — symbol map, name lookup and submodule list all compare
  equal to the post-v0.28.3 capture. `DgProxyCommand` and `cli.commands` both still present.
  API index table still 58 rows.
- `nox -s check_docs` passes with **0 warnings** and no `could not be resolved` lines.
- See Also unchanged: 63 sections, 131 entries, **0 unlinked** (audited shape-agnostically
  on `id="see-also"` headings scoped to `<article>`).
- **`git diff --stat -- docs/assets` empty**; all 25 files match their pre-update `sha256`.
- **`.github/workflows/` byte-identical** — `diff -r` exits 0. `test-versions` intact at
  `nightly.yml:45` with `needs: [test, test-versions]` on line 49.
- `mkdocs.yml` untouched: `warn_unknown_params: false` (line 197) and snippets
  `base_path: [docs, .]` both intact.

## Conflicts

**None.** `git status --porcelain` shows no `U` states and a `.rej`/`.orig` glob returns
nothing — both checked, since copier delivered the v0.28.2 conflict as an inline `UU` rather
than a reject file.
