### PR TITLE
chore(template): update to v0.32.1 (pre-push gates + CI roll-up)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 9f3aeacf02910bb8fa1d1dce087f5077b4f0925e
+_commit: ca1a612b33a5aee9a77fa5c10e9917a65ecfacb0
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: ca1a612b33a5aee9a77fa5c10e9917a65ecfacb0
+_commit: 96769caeb3394e1e3e13a8cde94b3caf5a92b277
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -10,7 +10,13 @@ jobs:
     name: Validate Commit Message
     runs-on: ubuntu-latest
 
-    # Only single-commit PRs. GitHub's `squash_merge_commit_title` defaults to
+    # This job always runs so it can be a *required* status check. A job gated off at the
+    # job level is skipped and reports no conclusion, which leaves a required check stuck
+    # "waiting" and blocks the PR. Instead the single-commit gate lives on each step: on a
+    # multi-commit PR the steps skip and the job still reports success, so the ruleset can
+    # require it unconditionally.
+    #
+    # Why single-commit only: GitHub's `squash_merge_commit_title` defaults to
     # COMMIT_OR_PR_TITLE, which takes the squash title from the commit when a PR has
     # exactly one commit and from the PR title otherwise. So this is precisely the case
     # where the commit message -- not the PR title -- is what git-cliff reads into the
@@ -18,12 +24,11 @@ jobs:
     # ship their title, so their intermediate commits stay free-form on purpose:
     # requiring conventional WIP messages that get squashed away is pure friction.
     #
-    # `commits` is the PR's commit count, which is the same input GitHub uses to make
-    # that choice. Counting changed files or diff hunks instead would gate the wrong PRs.
-    if: ${{ github.event.pull_request.commits == 1 }}
+    # `commits` is the PR's commit count, the same input GitHub uses to make that choice.
 
     steps:
       - name: Checkout the commit that will ship
+        if: ${{ github.event.pull_request.commits == 1 }}
         uses: actions/checkout@v7
         with:
           # The PR head itself, not the merge commit checkout/@v7 defaults to -- the
@@ -32,15 +37,18 @@ jobs:
           fetch-depth: 1
 
       - name: Install uv
+        if: ${{ github.event.pull_request.commits == 1 }}
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
           version: "0.10.0"
 
       - name: Set up Python
+        if: ${{ github.event.pull_request.commits == 1 }}
         run: uv python install
 
       - name: Validate the commit message that becomes the squash title
+        if: ${{ github.event.pull_request.commits == 1 }}
         run: |
           git log -1 --format=%B HEAD > "$RUNNER_TEMP/commit-msg"
           echo "Validating the message that will become the squash commit title:"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,3 +304,30 @@ jobs:
         run: |
           uv run python docs_build/build.py prebuild
           uv run --group docs mkdocs build --clean --strict
+
+
+  # Single required status check. The branch ruleset requires this one job, not the
+  # individual jobs above: test-fast is a matrix (its check-run names vary by OS/Python and
+  # differ between draft and ready PRs) and test-full is skipped on draft PRs, so neither
+  # can be named directly in a ruleset. This job depends on every blocking job and passes
+  # only when they all succeeded or were legitimately skipped, giving the ruleset one stable
+  # name that survives matrix and conditional changes. Validate PR Title and Validate Commit
+  # Message live in their own workflows and are required alongside this check.
+  ci-passed:
+    name: CI passed
+    if: always()
+    needs:
+      - test-fast
+      - test-full
+      - lint
+      - test_docstrings
+      - check_docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job did not pass
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::a required CI job failed or was cancelled"
+          exit 1
+      - name: All required jobs passed
+        run: echo "All required CI jobs passed or were legitimately skipped."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,11 +313,16 @@ jobs:
   # only when they all succeeded or were legitimately skipped, giving the ruleset one stable
   # name that survives matrix and conditional changes. Validate PR Title and Validate Commit
   # Message live in their own workflows and are required alongside this check.
+  #
+  # `test-compat` is listed even though it ships disabled (`if: false`): a skipped dependency
+  # does not fail an `if: always()` roll-up, so this is a harmless no-op until a project
+  # enables compat pins, at which point that job is gated automatically without touching this.
   ci-passed:
     name: CI passed
     if: always()
     needs:
       - test-fast
+      - test-compat
       - test-full
       - lint
       - test_docstrings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
-# `install` creates only the pre-commit hook unless told otherwise, so commitizen's
-# `stages: [commit-msg]` hook was declared but never installed -- the gate existed on
-# paper and never once ran. Naming both types here is what makes `prek install` wire up
-# the commit-msg hook that validates the message a single-commit PR ships.
-default_install_hook_types: [pre-commit, commit-msg]
+# `install` creates only the pre-commit hook unless told otherwise, so any hook pinned to
+# another stage would be declared but never installed -- the gate would exist on paper and
+# never run (as commitizen's `commit-msg` hook once did). Naming every stage here is what
+# makes `prek install` wire up the commit-msg hook that validates a single-commit PR's
+# message and the pre-push hooks (ty, interrogate, no-rst-citations) that gate before a push.
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
 repos:
   # prek's built-in Rust implementations, declared explicitly. Pointing these at
@@ -43,7 +44,10 @@ repos:
   # than every contributor paying 16 packages for it.
   - repo: local
     hooks:
-      # Docstring coverage
+      # Docstring coverage. Runs at pre-push, not pre-commit: it scores a pooled
+      # average across the whole package rather than the staged files, so it gives
+      # no per-commit signal, and running it on every commit only refuses commits
+      # and fires on old code during a rebase. pre-push runs it once before sharing.
       - id: interrogate
         name: interrogate
         entry: uv run --locked interrogate
@@ -52,6 +56,7 @@ repos:
         files: ^src/
         exclude: .*_version\.py$
         require_serial: true
+        stages: [pre-push]
 
       # Ban reStructuredText citation syntax in docstrings. numpydoc "References"
       # sections must use a markdown ordered list with plain `[1]` prose citations,
@@ -60,6 +65,7 @@ repos:
       # page. The docs build normalizes it anyway, but catching it at author time
       # keeps the source clean. `pygrep` is built into prek, so this adds no
       # dependency; it fails when either form matches.
+      # A whole-source docstring gate like interrogate/ty, so it runs at pre-push too.
       - id: no-rst-citations
         name: no reStructuredText citation syntax in docstrings
         description: Use a markdown ordered list and plain `[1]` citations, not RST `.. [1]` / `[1]_`.
@@ -67,6 +73,7 @@ repos:
         entry: '(^\s*\.\. \[|\[[^]]+\]_)'
         types: [python]
         files: ^src/
+        stages: [pre-push]
 
       # Ruff linter (autofix)
       - id: ruff
@@ -104,6 +111,7 @@ repos:
 
       # Type checking with ty. --extra mlflow so ty resolves the optional
       # mlflow code paths (utils.py, nodes.py) instead of emitting warnings.
+      # A whole-project, non-autofixing gate, so it runs at pre-push, not on every commit.
       - id: ty
         name: ty
         entry: uv run --extra mlflow --locked ty check --exit-zero-on-warning src
@@ -112,3 +120,4 @@ repos:
         files: ^src/
         pass_filenames: false
         require_serial: true
+        stages: [pre-push]

--- a/justfile
+++ b/justfile
@@ -7,10 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
-    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
-    # every commit. `-f` overwrites instead. Measured; the migration notice
-    # prek prints names this flag, and this is the command people actually run.
+    # -f matters twice over. It overwrites an existing shim instead of chaining it:
+    # without it prek finds a pre-v0.27.0 shim, moves it to `.git/hooks/pre-commit.legacy`
+    # and CHAINS it -- both run on every commit. And it re-wires the hook set on an
+    # existing clone, which is how a clone that installed before `pre-push` was added
+    # picks up the pre-push gate instead of leaving it declared-but-never-run.
     uv run prek install -f
 
 # Run tests and doctests with parallel execution

--- a/noxfile.py
+++ b/noxfile.py
@@ -236,8 +236,13 @@ def lint(session: nox.Session) -> None:
 @nox.session(venv_backend="none")
 def fix(session: nox.Session) -> None:
     """Format the code base to adhere to our styles, and complain about what we cannot do automatically."""
-    # --locked pins the exact uv.lock versions, so a stale lock fails loudly here and
-    # local matches CI. It is also what keeps prek itself pinned -- never use `uvx prek`.
+    # Run at the pre-push stage. A hook with no `stages:` key runs at every stage, so this
+    # one pass covers the full suite: the autofixing formatters AND the pre-push gates (ty,
+    # interrogate, no-rst-citations), while excluding commitizen (pinned to commit-msg). A
+    # plain `prek run` uses the pre-commit stage, which since those gates moved to pre-push
+    # would silently skip them -- here and in the CI lint job that runs this session, a
+    # green check measuring nothing. --locked pins the exact uv.lock versions, so a stale
+    # lock fails loudly and local matches CI, and it keeps prek pinned -- never `uvx prek`.
     session.run(
         "uv",
         "run",
@@ -246,6 +251,8 @@ def fix(session: nox.Session) -> None:
         "run",
         "--all-files",
         "--show-diff-on-failure",
+        "--stage",
+        "pre-push",
         *session.posargs,
         external=True,
     )


### PR DESCRIPTION
Rolls template release **v0.32.0** into kedro-dagster (`_commit` 9f3aeac → ca1a612).

A CI/hooks-only release. Five content files change; no docs, nav, mkdocs.yml, example machinery, or binaries touched.

## Changes
- **`.pre-commit-config.yaml`** — `default_install_hook_types` gains `pre-push`; the whole-source docstring gates (`ty`, `interrogate`, `no-rst-citations`) move to `stages: [pre-push]`. The local `--extra mlflow` customization on the `ty` hook is preserved.
- **`justfile`** — comment on `install`'s `-f` flag expands; `uv run prek install -f` unchanged.
- **`noxfile.py`** — the `fix` session now runs `prek run ... --stage pre-push` so the pre-push gates are exercised locally and in CI's lint job.
- **`.github/workflows/tests.yml`** — new roll-up job `ci-passed` ("CI passed", `if: always()`) whose `needs` are `test-fast, test-full, lint, test_docstrings, check_docs` (no `examples` — this repo has `include_examples=False`). Gives the branch ruleset one stable required check.
- **`.github/workflows/commit-message.yml`** — the single-commit `if:` moves from the job to each step, so the job always reports a conclusion and can be required unconditionally.

## Notes
- One inline conflict in `.pre-commit-config.yaml` (comment-only, on the `ty` hook) was resolved keeping the local `--extra mlflow` description plus the template's new pre-push note.
- `test-versions` lives in the separate `nightly.yml` / `tests-versions.yml` workflows and is **not** (and cannot be) gated by `ci-passed`. Those were untouched by this release.
- `nox -s fix` passes locally.

Held for review — leave merge to the maintainer.
