### PR TITLE
chore(template): sync to v0.36.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: e748f5c10c0fdd611bbbdae3783c130a82da87bd
+_commit: 804bc6947a8671392eb93470bb7fe0b8874722ee
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,8 +16,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
 
@@ -44,9 +46,9 @@ jobs:
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7
-        if: ${{ matrix.python-version == '3.12' && env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.python-version == '3.12' }}
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
 
   # [ADDITION] Run versioned tests nightly
   test-versions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,8 +104,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -137,17 +139,17 @@ jobs:
         run: nox -s test --python ${{ matrix.python-version }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
+        if: ${{ !cancelled() && matrix.python-version == '3.11' }}
         uses: codecov/test-results-action@v1
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
           file: '${{ github.workspace }}/junit.${{ matrix.python-version }}.xml'
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v7
-        if: ${{ matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.python-version == '3.11' }}
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
           files: '${{ github.workspace }}/coverage.${{ matrix.python-version }}.xml'
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
Syncs kedro-dagster to python-package-copier template **v0.36.0**.

## Delta (v0.35.0 -> v0.36.0)
Config-only; touches no nav/docs/source.

1. **Codecov -> tokenless GitHub OIDC** in `tests.yml` and `nightly.yml`:
   drop the `CODECOV_TOKEN` env, add `permissions: id-token: write` (+ `contents: read`),
   and switch the Codecov upload/test-results steps to `use_oidc: true` (no stored token).
2. **scorecard.yml** was already hotfixed to `ossf/scorecard-action@v2.4.4`, so it reconciles
   cleanly against the template (no change in this PR).

## Preserved (copier does not own)
- Bespoke `tests-versions.yml` reusable workflow and the `nightly.yml` `test-versions` job
  + `needs: [test, test-versions]` roll-up — untouched.
- `docstring_options.warn_unknown_params: false` in `mkdocs.yml` (CI-critical) — intact.

## Verification
- `copier update --vcs-ref v0.36.0` applied cleanly: no `.rej`, no `UU` conflicts, only the 3
  expected files changed (`.copier-answers.yml`, `tests.yml`, `nightly.yml`).
- `nox -s check_docs`: build finished, **no issues found**.
- `nox -s test_fast-3.12`: 438 passed, 8 skipped. `nox -s lint`: successful.
- prek: all hooks pass.

Note: the `CODECOV_TOKEN` repo secret is intentionally left untouched.

---
Held for review; do not merge.