### PR TITLE
fix(deps): raise mlflow floor to >=3.13 to keep pyarrow cp314-capable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,12 @@ dependencies = [
 [project.optional-dependencies]
 mlflow = [
     "kedro-mlflow>=0.13",
-    "mlflow>=2.20",
+    # mlflow < 3.13 caps pyarrow at < 24, and pyarrow < 24 publishes no cp314
+    # wheels. Without this floor a resolver forced off a recent mlflow (e.g. by
+    # a security bump to a version its `cryptography` pin excludes) silently
+    # backtracks instead of failing, and the breakage only surfaces as a pyarrow
+    # source build on Python 3.14.
+    "mlflow>=3.13",
     "dagster-mlflow",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1922,7 +1922,7 @@ requires-dist = [
     { name = "kedro", specifier = ">=1.0.0" },
     { name = "kedro-datasets", specifier = ">=1.0.0" },
     { name = "kedro-mlflow", marker = "extra == 'mlflow'", specifier = ">=0.13" },
-    { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=2.20" },
+    { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=3.13" },
     { name = "pydantic", specifier = ">=2.0.0" },
 ]
 provides-extras = ["mlflow"]


### PR DESCRIPTION
## Description

Raises the `mlflow` extra floor from `>=2.20` to `>=3.13`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

The `mlflow>=2.20` floor let the resolver backtrack arbitrarily far when a newer mlflow became unsatisfiable. #154 tripped it: forcing `cryptography` to 50.0.0 (every mlflow caps it at `<49` or `<50`) made uv walk mlflow 3.14.0 → 3.2.0 instead of failing. mlflow 3.2.0 pins `pyarrow<22`, and pyarrow 21 ships no cp314 wheels, so the install fell back to a source build and died in CMake on every Python 3.14 job.

`mlflow>=3.13` is the first release whose pyarrow cap (`<25`) admits pyarrow 24, the first pyarrow with cp314 wheels. The same bump now fails at resolve time naming mlflow and cryptography, instead of silently downgrading twelve packages.

Related: #154, Dependabot alert #8.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

No locked versions change — mlflow stays 3.14.0 and pyarrow 24.0.0, so the lockfile diff is one line and this is a pure guardrail.

This does not make #154 mergeable; cryptography 50.0.0 is genuinely unsatisfiable alongside any mlflow that depends on cryptography.
