### PR TITLE
build(deps): bump gitpython from 3.1.55 to 3.1.58

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1302,14 +1302,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.55"
+version = "3.1.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bumps `gitpython` from 3.1.55 to 3.1.58 in `uv.lock`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): dependency security update

## Motivation and Context

Clears three open Dependabot alerts, all the same class — caller-controlled `**kwargs` forwarded into a git command without `Git.check_unsafe_options()`, reaching an option that names a filesystem path:

| Alert | Severity | Vulnerable sink | Fixed in |
|---|---|---|---|
| #2 `GHSA-3f7w-8rr8-f37f` | High, CVSS 8.1 | `IndexFile.checkout()`, `TagReference.create()` | 3.1.57 |
| #3 `GHSA-539m-9xh6-q6rr` | Medium, CVSS 6.5 | `Repo.archive()` denylist omits `--add-file` | 3.1.57 |
| #4 `GHSA-p538-c434-8v24` | Medium, CVSS 5.4 | `Commit.count()` → `rev-list --output` | 3.1.56 |

Nothing constrains the upgrade: `kedro` allows `gitpython>=3.0`, `mlflow-skinny` allows `gitpython>=3.1.9,<4`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Exposure is nil — this is hygiene, not an incident. GitPython is transitive only (`kedro`, `mlflow-skinny`), kedro-dagster never imports `git` itself, and none of the four vulnerable sinks are called by any installed package. The only use in the tree is read-only introspection (`Repo(...)`, `repo.git.diff()`, `ls_remote`, `rev_parse`).

Lock diff is three lines, one package; no other version moves.
