### PR TITLE
fix(ci): declare a read-only token for tests-versions

### DIFF
--- a/.github/workflows/tests-versions.yml
+++ b/.github/workflows/tests-versions.yml
@@ -13,6 +13,12 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Without this, the job inherits the repository's default token scope, which can be
+# read-write. `workflow_call` also lets a caller's scope flow in, so the floor has to
+# be declared here rather than assumed from whoever invokes it. Running tests reads.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Part of a fleet-wide security sweep of the org's Dependabot / malware / code-scanning alerts.

Scorecard reported `TokenPermissionsID` on `tests-versions.yml`: `score is 0: no topLevel permission defined`. With no `permissions` block the workflow inherits the repository's default token scope, which can be read-write.

It also exposes `workflow_call`, so a caller's scope flows in — the floor has to be declared in this file rather than assumed from whoever invokes it.

Running tests reads. The other two `TokenPermissionsID` findings on this repo are in `publish-release.yml`, are template-generated, and are legitimate.