### PR TITLE
fix(ci): name the nightly coverage upload and discover every Codecov step

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 2ef4acdac177596054e95a53c88406f215bc038a
+_commit: 10e9f41542bbcf96855ec8049cb1e0802572a610
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,13 @@ jobs:
         if: ${{ matrix.python-version == '3.12' }}
         with:
           use_oidc: true
+          # Named explicitly, with the uploader's search off. This step had
+          # neither for several releases: it uploaded whatever the fallback happened to
+          # find, which is the exact pattern the tests.yml upload was fixed to remove --
+          # and it survived that fix because the check only looked at tests.yml.
+          files: '${{ github.workspace }}/.artifacts/coverage.xml'
+          disable_search: true
+          fail_ci_if_error: true
 
   # [ADDITION] Run versioned tests nightly
   test-versions:

--- a/.gitignore
+++ b/.gitignore
@@ -80,11 +80,13 @@ examples/__marimo__/
 # database, which the generated conftest.py points under `.artifacts/`.
 #
 # Recent Hypothesis drops a self-ignoring `.gitignore` inside it, and this entry was
-# removed on the strength of that. It is version-dependent: 6.165.2 writes the file,
-# 6.151.9 does not, and the project floors at `hypothesis>=6.100`. A repo resolving
-# below the cutoff gets ~26 untracked files at its root -- the exact mess the
-# `.artifacts/` layout exists to prevent, reintroduced by trusting a library's
-# internal behaviour across a range it does not promise.
+# removed on the strength of that. It is version-dependent, and the project floors at
+# `hypothesis>=6.100`. Measured across the fleet: 6.151.9 does NOT write the file;
+# 6.156.9, 6.158.0, 6.161.2 and 6.165.2 all do -- so the cutoff sits between 6.151.9
+# and 6.156.9, and every repo measured happened to resolve above it. One did not, and
+# got ~26 untracked files at its root: the exact mess the `.artifacts/` layout exists to
+# prevent, reintroduced by trusting a library's internal behaviour across a range it
+# does not promise. Nothing pins the resolution, so the entry stays.
 .hypothesis/
 
 # Markdown linter cache. rumdl has no cache-path option, so unlike the caches

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -208,36 +208,61 @@ def test_every_reader_of_the_built_site_agrees_with_mkdocs():
         assert site_dir in text, f"{name} reads the built site but not at {site_dir!r} from mkdocs.yml `site_dir`"
 
 
-def test_coverage_upload_names_the_file_coverage_writes():
-    """The Codecov `files:` input must name the file the coverage config produces.
+def _workflows_uploading_coverage():
+    """Every workflow file containing a Codecov upload step.
+
+    Deliberately discovered, not listed. The first version of these checks named
+    `tests.yml` and nothing else, so a second upload in `nightly.yml` -- with no
+    `files:` and no `disable_search:`, relying entirely on the fallback -- sat
+    unnoticed through the release that removed exactly that pattern from `tests.yml`.
+    A check that names its own scope cannot see the instance it was not told about.
+    """
+    workflows = _PROJECT / ".github/workflows"
+    if not workflows.is_dir():
+        return []
+
+    return [
+        path for path in sorted(workflows.glob("*.yml")) if "codecov/codecov-action" in path.read_text(encoding="utf-8")
+    ]
+
+
+def test_a_coverage_upload_exists_to_check():
+    """Guard the input set, so the two checks below cannot pass over nothing."""
+    assert _workflows_uploading_coverage(), (
+        "no workflow uploads coverage, so the assertions about upload paths measure nothing"
+    )
+
+
+def test_every_coverage_upload_names_the_file_coverage_writes():
+    """Each Codecov `files:` input must name the file the coverage config produces.
 
     These drifted apart once before and nothing noticed, because the uploader's
-    fallback search found the real report and reported success.
+    fallback search found the real report and reported success anyway.
     """
     pyproject = (_PROJECT / "pyproject.toml").read_text(encoding="utf-8")
     written = re.search(r"\[tool\.coverage\.xml\][^\[]*?output\s*=\s*\"([^\"]+)\"", pyproject, re.S)
     assert written, "pyproject.toml does not set [tool.coverage.xml] output; the report path is undefined"
 
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-    uploaded = re.search(r"files:\s*'\$\{\{ github\.workspace \}\}/([^']+)'", workflow)
-    assert uploaded, "the coverage upload step does not name a file"
+    for path in _workflows_uploading_coverage():
+        text = path.read_text(encoding="utf-8")
+        uploaded = re.search(r"files:\s*'?\$\{\{ github\.workspace \}\}/([^'\s]+)'?", text)
 
-    assert uploaded.group(1) == written.group(1), (
-        f"coverage upload reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
-    )
+        assert uploaded, f"{path.name} uploads coverage without naming a file, so it relies on the fallback search"
+        assert uploaded.group(1) == written.group(1), (
+            f"{path.name} reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
+        )
 
 
-def test_coverage_upload_does_not_fall_back_to_searching():
+def test_no_coverage_upload_falls_back_to_searching():
     """`fail_ci_if_error` only means something with the uploader's search disabled.
 
     With search on, a `files:` input naming nothing is not an error: the CLI scans
     the workspace, uploads whatever it finds, and the step passes.
     """
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-
-    assert "disable_search: true" in workflow, (
-        "the coverage upload leaves search enabled, so a wrong `files:` path cannot fail the build"
-    )
+    for path in _workflows_uploading_coverage():
+        assert "disable_search: true" in path.read_text(encoding="utf-8"), (
+            f"{path.name} leaves the uploader's search enabled, so a wrong `files:` path cannot fail the build"
+        )
 
 
 def test_the_scan_can_fail(tmp_path):


### PR DESCRIPTION
**Held for review — do not merge.** Opened by a template fan-out; the maintainer decides when this lands.

Update from python-package-copier **v0.41.2 → v0.41.4**. Four files, and it deliberately skips the
withdrawn v0.41.3 (`--vcs-ref v0.41.4` pinned explicitly).

## What lands

- **`nightly.yml`'s Codecov step named no file and left the uploader's search on**, so it uploaded
  whatever the fallback happened to find. That is the exact pattern removed from `tests.yml` one
  release earlier — and it survived that fix because the check enforcing it read `tests.yml` **by
  name** and could not see a second upload. The step now names `.artifacts/coverage.xml` with
  `disable_search: true` and `fail_ci_if_error: true`.
- **`tests/test_artifact_paths.py` no longer names its own scope.** It discovers every workflow
  containing a `codecov/codecov-action` step and asserts the path and the search setting on each,
  plus a new guard test so the discovered set cannot silently empty and let the other two pass over
  nothing. **Here it discovers two — `nightly.yml` and `tests.yml` — where the old version saw one.**
- **`.gitignore`** — comment correction only: the Hypothesis self-ignore cutoff sits between 6.151.9
  and 6.156.9, measured across the fleet, not near 6.165.2.

## Verification

- **`tests/conftest.py` is byte-identical**, hash-checked before and after
  (`dd61ea975ca8756612a58c752af9542aecdb5f0b`, 409 lines). This is why v0.41.3 was skipped: it moved
  a block inside that file, which made copier reject the whole thing and revert it to the stub.
- **Zero conflicts, zero `.rej`, no conflict markers, no `U` states.** `nightly.yml` was expected to
  reject with the `test-versions` job inside the `.rej`; it did not — it applied as a clean +7-line
  insert. Verified whole-file anyway rather than trusting the clean result: job set identical (6
  jobs), `test-versions` intact (shifted line 54→61), `needs: [test, test-versions, release-smoke]`
  intact (118→125), 163→170 lines.
- **The gate is green and non-vacuous: 7/7.** Falsified against a **scratch copy** of the tree with
  `nightly.yml`'s `files:`/`disable_search:` stripped — both checks then fail, **by name**
  (`nightly.yml uploads coverage without naming a file, so it relies on the fallback search`). The
  live file was never touched.
- **Nothing regressed**: `docs/assets` diff empty; nav **27** per section (Home 1, Tutorials 4,
  How-to Guides 10, Explanation 6, Reference 6) with `mkdocs.yml` untouched by this release;
  `warn_unknown_params: false` present; snippets `base_path: [docs, .]`; `tests-versions.yml`
  **byte-identical** (sha unchanged); **49** digest-pinned `uses:` lines, **0** tag-pinned, **13**
  `setup-uv` `version: "0.12.1"` pins.
- 445 passed / 8 skipped locally (444 + the new guard test); `prek run --all-files` 13/13.
