### PR TITLE
ci(release): verify tag signatures, allow publish retries, and automerge dep updates

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -97,6 +97,11 @@ docs/pages/how-to/contribute.md
 docs/pages/explanation/security.md
 .github/workflows/tests.yml        # conditional: include_actions
 .github/workflows/pr-title.yml     # conditional: include_actions
+.github/workflows/renovate-automerge.yml  # conditional: include_actions. The guard is
+                                   # template-owned: it must keep requiring the
+                                   # `automerge` label, or the workflow starts approving
+                                   # updates nothing chose to automate. A project may add
+                                   # its own steps, so merge rather than overwrite.
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 7419e837c85f2cbc9df575297b3f9f6e7573dc89
+_commit: 30b1dc6b23390359f038547144be9f0c9fd67581
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,69 @@ permissions:
   pull-requests: read
 
 jobs:
+  # A human creates the release tag, and that push is what triggers this workflow, so
+  # no automation exists at the moment the tag comes into being: by the time anything
+  # can object, the tag is already public. This job is the first automated thing to see
+  # it, and it runs before the changelog pull request opens and long before anything is
+  # published, so a rejected release costs a force-deleted tag rather than a withdrawn
+  # artifact.
+  #
+  # It exists because "release tags are signed" was written in the contributing guide
+  # and in the security posture, believed, and measured by nothing -- five consecutive
+  # releases of the template that generates this workflow carried no signature at all
+  # and no one found out until someone went looking. A control nothing measures is a
+  # claim, so this is deliberately the cheapest possible job: no checkout, no actions,
+  # no third party in the release path.
+  verify-tag-signature:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the release tag carries a verifiable signature
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Read from the environment, never through an Actions expression: those are
+          # substituted into the script body before bash parses it, and a tag name is
+          # attacker-influenced text.
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+
+          # A lightweight tag is a ref pointing straight at a commit, with no tag object
+          # to carry a signature. Report it separately from an unsigned annotated tag,
+          # because "you forgot -s" and "you forgot -a" read identically in the failure
+          # and are fixed the same way only by accident.
+          REF=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" \
+            --jq '.object.type + " " + .object.sha')
+          OBJECT_TYPE="${REF%% *}"
+          OBJECT_SHA="${REF##* }"
+
+          if [ "$OBJECT_TYPE" != "tag" ]; then
+            echo "::error::${TAG_NAME} is a lightweight tag, so there is no tag object to sign." \
+              "Delete it (git push --delete origin ${TAG_NAME}) and recreate it with" \
+              "'git tag -s ${TAG_NAME} -m \"Release ${TAG_NAME}\"'."
+            exit 1
+          fi
+
+          # Ask the forge whether the signature verifies, rather than grepping the tag
+          # body for a PGP block. A malformed or unknown-key signature contains the
+          # block and proves nothing, so a grep would be a check that passes on exactly
+          # the input it exists to reject.
+          TAG_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${OBJECT_SHA}")
+          VERIFIED=$(printf '%s' "$TAG_JSON" | jq -r '.verification.verified')
+          REASON=$(printf '%s' "$TAG_JSON" | jq -r '.verification.reason')
+
+          if [ "$VERIFIED" != "true" ]; then
+            echo "::error::${TAG_NAME} has no verifiable signature (reason: ${REASON})." \
+              "Sign release tags with 'git tag -s', and make sure the public half of the" \
+              "signing key is registered on the tagger's account so the signature can be" \
+              "checked by someone who is not you. See the release section of the" \
+              "contributing guide."
+            exit 1
+          fi
+
+          echo "${TAG_NAME} is signed and the signature verifies."
+
   changelog:
+    needs: verify-tag-signature
     runs-on: ubuntu-latest
     steps:
       # Mint a short-lived, scoped token from the fleet automation GitHub App. A PR

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,20 @@ on:
     types: [closed]
     branches:
       - main
+  # A publish can fail for reasons that have nothing to do with the release: an
+  # upstream action shipping a broken dependency, a registry outage, a revoked
+  # token. Without this trigger the `pull_request: closed` event is spent the
+  # moment it fires, so the only way to retry was to delete the tag and cut a new
+  # version -- which also rewrites the changelog and burns a version number for a
+  # fault the release never had. Dispatch re-runs the same pipeline against an
+  # existing tag. The `pypi` environment gate still applies, so a retry is no
+  # less reviewed than the original.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing release tag to publish, e.g. v1.2.3"
+        required: true
+        type: string
 
 # Least-privilege default: read-only token unless a job widens it explicitly.
 permissions:
@@ -20,26 +34,36 @@ jobs:
   # build previously lived in changelog.yml and was fetched across workflows with a
   # third-party action; keeping it here removes that third party from the release path.
   build:
-    # Only run if PR was merged and has the changelog label
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'changelog')
+    # A merged, changelog-labelled PR, or an explicit dispatch naming a tag.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'changelog'))
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.find_tag.outputs.version }}
     steps:
       - name: Find release tag
         id: find_tag
-        # The PR title reaches the shell through the environment, never through
-        # an expression inside `run:`. An expression is substituted into the
-        # script before bash parses it, so a title carrying shell metacharacters
-        # would execute here -- in a job that goes on to publish. An env var is data.
+        # Both the PR title and the dispatch input reach the shell through the
+        # environment, never through an expression inside `run:`. An expression is
+        # substituted into the script before bash parses it, so a value carrying
+        # shell metacharacters would execute here -- in a job that goes on to
+        # publish. An env var is data. The dispatch input is attacker-reachable by
+        # anyone who can run a workflow, so it gets the same treatment as the title.
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
-          VERSION=$(printf '%s' "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
+          # One extraction validates both paths, so a dispatch input that is not a
+          # version fails closed here rather than reaching `checkout` as a ref.
+          # Extract from the dispatch input, else the PR title (e.g.
+          # "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1").
+          SOURCE="${INPUT_VERSION:-$PR_TITLE}"
+          VERSION=$(printf '%s' "$SOURCE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
-            echo "No version found in PR title"
+            echo "No version found in ${INPUT_VERSION:+the workflow_dispatch input}${INPUT_VERSION:-the PR title}"
             exit 1
           fi
 
@@ -154,16 +178,35 @@ jobs:
       # is public until the `pypi` environment gate has been approved and the upload
       # has succeeded. `finalize-release` undrafts it. If the gate is rejected or the
       # upload fails, the draft is all that exists and can simply be deleted.
-      - name: Create draft GitHub Release
+      - name: Create or refresh the draft GitHub Release
+        # RELEASE_NOTES is an env var, not an expression inside `run:`, for the same
+        # reason the PR title is: the notes are built from commit subjects, so a
+        # subject containing shell metacharacters would otherwise be pasted into this
+        # script and executed. VERSION is interpolated because it cannot be anything
+        # else -- it is whatever the `find_tag` regex matched, and nothing wider.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}
         run: |
           VERSION="${{ needs.build.outputs.version }}"
-          gh release create "$VERSION" \
-            --draft \
-            --title "$VERSION" \
-            --notes "${{ steps.release_notes.outputs.notes }}" \
-            dist/* sbom/sbom.cdx.json
+          # A retry reaches this job with the previous attempt's release already in
+          # place -- that is the normal case, since a publish that fails at the upload
+          # leaves its draft behind. `gh release create` exits non-zero on an existing
+          # tag, so without this branch the dispatch trigger could never serve the one
+          # situation it exists for. Refresh the existing release instead, and do not
+          # re-draft one that is already public: undrafting is `finalize-release`'s
+          # decision, taken only after a successful upload.
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists; refreshing its notes and artifacts"
+            gh release upload "$VERSION" dist/* sbom/sbom.cdx.json --clobber
+            gh release edit "$VERSION" --notes "$RELEASE_NOTES"
+          else
+            gh release create "$VERSION" \
+              --draft \
+              --title "$VERSION" \
+              --notes "$RELEASE_NOTES" \
+              dist/* sbom/sbom.cdx.json
+          fi
 
   pypi-publish:
     name: Publish to PyPI

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -1,0 +1,72 @@
+name: Renovate Automerge
+
+# Renovate cannot approve its own pull request, so a branch ruleset that requires an
+# approving review blocks every unattended dependency update no matter what
+# `automerge` is set to in renovate.json. This workflow supplies that approval for the
+# update classes renovate.json already marked as safe to merge unattended, then hands
+# the PR to GitHub's own auto-merge queue. The required status checks still gate the
+# merge: auto-merge waits for them, so a red CI run means the PR sits unmerged.
+
+on:
+  pull_request:
+    # `labeled` matters as much as `opened`: Renovate creates the PR first and applies
+    # labels in a second API call, so the `opened` payload can arrive with an empty
+    # label list and the guard below would reject a PR that is in fact eligible.
+    types: [opened, reopened, synchronize, labeled]
+    branches: [main]
+
+# Least-privilege default: read-only token; the job below widens only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  automerge:
+    name: Approve and enable automerge
+    # Three independent conditions, all required.
+    #
+    # Deliberately NOT keyed on a literal bot login. The account name is the GitHub
+    # App's slug, which differs per installation: a self-hosted App shows up as
+    # `<app-slug>[bot]` (this fleet's is `stateful-y-renovate[bot]`), not the
+    # `renovate[bot]` of the hosted Mend app. Hardcoding either one gives a workflow
+    # that passes its own syntax checks and then silently never fires.
+    #
+    # The `automerge` label is the authorization signal. renovate.json applies it on
+    # exactly the rules that also set `automerge: true`, and nowhere else, so major
+    # bumps and the grouped runtime dependency PR carry no label and stay fully
+    # manual. Applying a label needs write access, so an outside contributor cannot
+    # forge the signal, and the branch-prefix and Bot-author checks keep a human PR
+    # from ever being auto-approved.
+    if: >-
+      github.event.pull_request.user.type == 'Bot'
+      && startsWith(github.event.pull_request.head.ref, 'renovate/')
+      && contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    permissions:
+      # `gh pr merge --auto` writes the auto-merge setting on the PR.
+      contents: write
+      # `gh pr review --approve` needs write, and the org or repository setting
+      # "Allow GitHub Actions to create and approve pull requests" must be enabled
+      # or this step fails with a 403.
+      pull-requests: write
+    steps:
+      - name: Approve the update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # Idempotent: re-approving an already-approved PR is not an error, which
+          # matters because `synchronize` fires again on every Renovate rebase.
+          gh pr review --approve "$PR_URL" \
+            --body "Approved automatically: this update is in the automerge scope set by .github/renovate.json. The required status checks still gate the merge."
+
+      - name: Hand the PR to GitHub auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # Renovate's `platformAutomerge` normally does this at creation time. Doing
+          # it here too covers the case where that call failed, and fails loudly if
+          # the repository has "Allow auto-merge" switched off, rather than leaving
+          # the PR to sit unexplained. Squash is the only merge method the ruleset
+          # permits.
+          gh pr merge --auto --squash "$PR_URL"

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -547,49 +547,75 @@ graph LR
 
 ### How It Works
 
-1. **Tag a release** (signed with [gitsign](https://github.com/sigstore/gitsign) keyless Sigstore signing):
+1. **Tag a release** (the tag must be signed, and CI rejects it if it is not):
 
     ```bash
    git tag -s v0.2.0 -m "Release v0.2.0"
    git push origin v0.2.0
     ```
 
-    One-time gitsign setup so `git tag -s` signs via Sigstore, with no long-lived GPG key to manage:
+    One-time setup so `git tag -s` works, and so the signature is verifiable by someone who is not you:
 
     ```bash
-   git config --local gpg.x509.program gitsign
-   git config --local gpg.format x509
+   git config --local user.signingkey <your-key-id>
    git config --local tag.gpgSign true
     ```
 
-    The first signing authenticates via your identity provider in a browser; verify a tag with `gitsign verify-tag`. Signed tags complement the PEP 740 artifact attestations the publish workflow already produces, so both the tag and the published artifacts are verifiable.
+    Upload the public half of that key to your account's SSH and GPG keys settings. This is not optional bookkeeping: the release check asks the forge whether the signature verifies, and a signature made with a key nobody can look up fails exactly like no signature at all. Signed tags complement the PEP 740 artifact attestations the publish workflow already produces, so both the tag and the published artifacts are verifiable.
 
-2. **Automated changelog workflow** (`changelog.yml`):
+2. **Signature check** (`changelog.yml`, job `verify-tag-signature`):
+    - Runs before every other job, and gates them through `needs`
+    - Rejects a lightweight tag (there is no tag object to sign) and an unverifiable signature, with a different message for each
+    - Pushing the tag is what starts the workflow, so this is detection rather than prevention: the tag is already public when the check runs. It fires before the changelog PR opens and long before anything reaches PyPI, so recovery is `git push --delete origin v0.2.0` and a re-tag
+
+3. **Automated changelog workflow** (`changelog.yml`):
     - Generates changelog from conventional commits using git-cliff
     - Creates a **Pull Request** with the updated CHANGELOG.md
     - Builds the package distributions (wheels and sdist) for **immediate validation**
     - Stores distributions as workflow artifacts (reused later to avoid rebuilding)
 
-3. **Review and merge the changelog PR:**
+4. **Review and merge the changelog PR:**
     - A maintainer reviews the generated changelog
     - Once approved, merge the PR to main
 
-4. **Automated release workflow** (`publish-release.yml`):
+5. **Automated release workflow** (`publish-release.yml`):
     - Creates a GitHub Release with generated release notes
     - Attaches distribution files to the release
     - **Waits for manual approval** before proceeding to PyPI
 
-5. **Manual approval for PyPI publishing:**
+6. **Manual approval for PyPI publishing:**
     - Designated reviewers receive a notification
     - Review the GitHub Release to verify everything is correct
     - Approve the deployment to publish to PyPI
     - Package is published using Trusted Publishing (OIDC, no tokens needed)
 
-6. **Release notes generation:**
+7. **Release notes generation:**
     - All commits since the last tag are analyzed
     - Commits are grouped by type (Added, Fixed, Documentation, etc.)
     - Only commits following conventional format are included
     - Breaking changes are highlighted
+
+### If the publish fails
+
+A publish can fail for reasons that have nothing to do with the release: an upstream
+action shipping a broken dependency, a registry outage, a revoked token. The merge that
+started it cannot be replayed, and re-running the failed job reuses the old workflow
+file, so fixing the cause on `main` is not enough on its own.
+
+Fix the cause, then re-run the pipeline against the **same tag**:
+
+```bash
+gh workflow run publish-release.yml -f version=v0.2.0
+```
+
+The retry rebuilds from the tag, refreshes the existing GitHub Release rather than
+failing on it, and still stops at the `pypi` approval gate. Do **not** delete the tag and
+cut a new version to work around a failed publish: that rewrites the changelog and spends
+a version number on a fault the release never had.
+
+One case this does not cover: if the previous attempt uploaded some files to PyPI before
+failing, the retry stops on the duplicates, because PyPI does not accept a re-upload of a
+file it already has. Bump to a new version for that.
 
 ### Version Numbering
 


### PR DESCRIPTION
**Held for review, do not merge.** Template fan-out of python-package-copier
`v0.41.5` -> `v0.42.0`, one of seven repos. Merge is the user's call.

## What lands

| file | change |
|---|---|
| `.github/workflows/changelog.yml` | +62. New `verify-tag-signature` job, gating the rest via `needs`. |
| `.github/workflows/publish-release.yml` | +58/-15. `workflow_dispatch` retry against an existing tag; the draft-release step refreshes instead of failing. |
| `.github/workflows/renovate-automerge.yml` | **new**, 72 lines. Approves and auto-merges the Renovate PR classes the shared preset marks safe. |
| `docs/pages/how-to/contribute.md` | +36/-10. Signing docs gitsign -> GPG, steps renumbered, new "If the publish fails" section. |
| `.claude/skills/update-from-template/references/file-classification.md` | +5, tier entry for the new workflow. |
| `.copier-answers.yml` | `_commit` -> `30b1dc6`. |

## Update hygiene

- `copier update --vcs-ref v0.42.0`: exit 0, **0** `.rej`, **0** inline conflict markers,
  **0** `U` states. The marker sweep was falsified against an injected
  `<<<<<<< HEAD` / `=======` / `>>>>>>> theirs` triple in a scratch file first, so the zero is
  a measurement rather than a blind spot.
- The applied per-file `+/-` is **exactly** the pristine v0.41.5 -> v0.42.0 render delta at this
  repo's own answers (5/0, 1/1, 62/0, 58/15, 36/10). Nothing local was bundled into a rejected
  hunk.
- `contribute.md`, `renovate-automerge.yml` and `file-classification.md` came out
  **byte-identical to a fresh `copier copy` at v0.42.0**.
- **All 49 action digest pins preserved**, each with its `# vN` comment; **0** bare-tag `uses:`
  lines. All 13 `astral-sh/setup-uv` `version: "0.12.1"` inputs preserved, with no `"0.10.0"`
  anywhere. This release changes no `uses:` line, so the local digests stay. Each digest was
  resolved against the template's tag and matches it exactly, so nothing here is a stale pin.
- `git diff --stat -- docs/assets` is **empty**.
- Untouched, as expected: `mkdocs.yml` (nav still 27 leaves across the same 5 sections),
  `.github/renovate.json`, `tests/conftest.py`, `docs_build/*`, `pyproject.toml`, `noxfile.py`,
  `justfile`, `CONTRIBUTING.md`, `.gitignore`, and every other workflow.
- `nightly.yml`'s `test-versions` job survives intact: still a `uses:` call to
  `./.github/workflows/tests-versions.yml` with zero inline steps, still listed in
  `create-issue-on-failure`'s `needs`. Checked by name from parsed YAML, not by line number.
- `prek run --all-files`: all 13 hooks pass, including `check for merge conflicts` and
  `rumdl check` on the changed markdown, with `.rumdl_cache` cleared first.

## What this PR does not prove

- **`changelog.yml` and `publish-release.yml` have no `pull_request` trigger.** Every green
  tick below proves their YAML parses and nothing more. Neither was dispatched: running
  `publish-release.yml` would create a GitHub Release and can publish to PyPI, and exercising
  `changelog.yml` needs a pushed tag. Both were verified statically.
- **`renovate-automerge.yml` correctly does not appear in the check list.** Its guard needs a
  Bot author, a `renovate/` head branch and the `automerge` label. Its absence is the expected
  result, not a failure.
- `Compat tests` is hardcoded `if: false` in this repo. Pre-existing; its green is vacuous.
- `Validate Commit Message` passes vacuously on a multi-commit PR (the `if` is step-level), so
  GitHub takes the squash title from this PR's title.

## Action required before the new workflow can work (repo setting, not code)

`renovate-automerge.yml`'s approve step runs `gh pr review --approve`, which needs
**"Allow GitHub Actions to create and approve pull requests"**. The `stateful-y` org has it
enabled, but this repo carries a repo-level override set to `false`:

```text
repos/stateful-y/kedro-dagster  can_approve_pull_request_reviews = false
```

So the workflow will merge green (it never runs on this PR) and then fail with a 403 the first
time a Renovate PR arrives. `yohou-nixtla` carries the same override; the other five repos are
`true`. `allow_auto_merge` is already `true` here and squash is the only permitted merge
method, which is what the workflow assumes.

The authorization signal itself checks out: `stateful-y/renovate-config` does apply the
`automerge` label on exactly the rules that also set `automerge: true`, so this is not dead
code. The `automerge` label does not exist on the repo yet; Renovate creates it on demand.
