### PR TITLE
docs(citation): tell users how to cite kedro-dagster

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -73,9 +73,18 @@ docs/stylesheets/theme.css
 .github/PULL_REQUEST_TEMPLATE.md
 SECURITY.md
 .claude/skills/**                   # Skill files managed by template (the tracked copy)
-.github/skills/**                   # Byte-identical Copilot mirror; gitignored, so an
-                                    # update never delivers it -- copier works through
-                                    # git and skips ignored paths. Edit .claude/skills.
+.github/skills/**                   # Byte-identical Copilot mirror. Gitignored, so an
+                                    # update writes it to disk UNTRACKED: the change is
+                                    # delivered, and no one reviews it because it never
+                                    # reaches a diff. Measured on the v0.43.0 fan-out,
+                                    # where copier updated this very file in all seven
+                                    # repos while `git status` stayed silent.
+                                    #
+                                    # This entry used to say copier "skips ignored
+                                    # paths" and that an update "never delivers it".
+                                    # Both halves are wrong. Do not rely on either:
+                                    # if you need to know what landed here, look at
+                                    # the file on disk, not at git. Edit .claude/skills.
 ```
 
 ---

--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -95,6 +95,14 @@ docs/index.md
 docs/pages/reference/api.md
 docs/pages/how-to/contribute.md
 docs/pages/explanation/security.md
+docs/pages/reference/citation.md   # prose copy of the citation; a project may add a
+                                   # paper or a DOI to it
+CITATION.cff                       # renders entirely from copier answers, which argues
+                                   # for Tier 1. Against that: the commented `doi:` line
+                                   # exists precisely so a project can fill it in, and a
+                                   # Tier 1 overwrite would delete that DOI with no
+                                   # conflict, no .rej and no output, the same silent
+                                   # loss as the logos.
 .github/workflows/tests.yml        # conditional: include_actions
 .github/workflows/pr-title.yml     # conditional: include_actions
 .github/workflows/renovate-automerge.yml  # conditional: include_actions. The guard is

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 30b1dc6b23390359f038547144be9f0c9fd67581
+_commit: 80b92b27698c3755d6d432d34ce2dca65bcab19e
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,12 +1,12 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 80b92b27698c3755d6d432d34ce2dca65bcab19e
+_commit: b6e06378b2e2967808bfb55f68f0affad0fcca28
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin
 code_owner: '@gtauzin'
-description: Kedro-Dagster makes it easy to deploy Kedro projects to Dagster
+description: Deploy Kedro projects to Dagster
 github_username: stateful-y
 include_actions: True
 include_codecov: True

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -30,12 +30,24 @@ jobs:
     # `renovate[bot]` of the hosted Mend app. Hardcoding either one gives a workflow
     # that passes its own syntax checks and then silently never fires.
     #
-    # The `automerge` label is the authorization signal. renovate.json applies it on
-    # exactly the rules that also set `automerge: true`, and nowhere else, so major
-    # bumps and the grouped runtime dependency PR carry no label and stay fully
-    # manual. Applying a label needs write access, so an outside contributor cannot
-    # forge the signal, and the branch-prefix and Bot-author checks keep a human PR
-    # from ever being auto-approved.
+    # The `automerge` label is the authorization signal, applied on exactly the rules
+    # that also set `automerge: true` and nowhere else, so major bumps and the grouped
+    # runtime dependency PR carry no label and stay fully manual. Applying a label needs
+    # write access, so an outside contributor cannot forge the signal, and the
+    # branch-prefix and Bot-author checks keep a human PR from ever being auto-approved.
+    #
+    # WHERE those rules live depends on how this project is configured, and the answer
+    # is not always this repository:
+    #
+    #   - No `renovate_preset`: they are in `.github/renovate.json` here.
+    #   - A `renovate_preset` is set: `.github/renovate.json` is a four-line stub that
+    #     extends the preset, and the rules are in THAT repository. Nothing in this repo
+    #     mentions them.
+    #
+    # This comment named only the first case until the v0.42.0 fan-out, which is the
+    # case that does not apply to any repository generated with a preset. Someone
+    # debugging "why did nothing get approved" would have opened a file containing none
+    # of the relevant configuration.
     if: >-
       github.event.pull_request.user.type == 'Bot'
       && startsWith(github.event.pull_request.head.ref, 'renovate/')

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,8 +23,9 @@ build:
     # on sys.path (via the wheel's `dev-mode-dirs`) so the build loads the
     # `docs_build` markdown extensions by module name. `uv run` uses that venv.
     - asdf plugin add uv || true
-    - asdf install uv latest
-    - asdf global uv latest
+    # renovate: datasource=github-releases depName=astral-sh/uv
+    - asdf install uv 0.10.0
+    - asdf global uv 0.10.0
     - uv sync --group docs
     # Generate the API pages and export the notebooks -- the explicit step that
     # replaced the deleted on_pre_build hook.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+# How to cite Kedro-Dagster, in the one form machines read. GitHub renders the
+# "Cite this repository" button from this file, and reads it from the default
+# branch's ROOT only: moving it under `.github/` or `docs/` does not relocate the
+# consumer, it removes the only one. Same reason `LICENSE` stays at the root.
+#
+# There is deliberately no `version:` and no `date-released:` here. Both are optional
+# in the format, GitHub's button works without them, and both are wrong the day after
+# the next release. Keeping them right would mean a step in the release workflow, and
+# what it would buy is a version number a reader can already get from PyPI. Add them
+# yourself if you need version-specific citation.
+#
+# The prose copies of this citation live in README.md and
+# docs/pages/reference/citation.md. All three render from the same answers.
+cff-version: 1.2.0
+message: "If you use Kedro-Dagster in your work, please cite it as below."
+title: "Kedro-Dagster"
+abstract: "Kedro-Dagster makes it easy to deploy Kedro projects to Dagster"
+type: software
+authors:
+  # Recorded as a single `name`, which the format treats as an entity rather than a
+  # person. That is deliberate: splitting "Guillaume Tauzin" into given and family
+  # names means guessing where one ends and the other begins, and a template that
+  # guesses wrong ships a misattributed citation. If the author is a person, replace
+  # `name` with `given-names` and `family-names` here. This file is merge-required,
+  # not template-managed, so that edit survives template updates.
+  - name: "Guillaume Tauzin"
+    email: "gtauzin@stateful-y.io"
+repository-code: "https://github.com/stateful-y/kedro-dagster"
+url: "https://kedro-dagster.readthedocs.io/"
+license: Apache-2.0
+# No DOI is assigned to this project. If you deposit a release (Zenodo, for
+# example), uncomment the line below and paste the CONCEPT DOI, the one that always
+# resolves to the latest version, rather than a single release's DOI.
+# doi: 10.5281/zenodo.XXXXXXX

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,12 @@
 # docs/pages/reference/citation.md. All three render from the same answers.
 cff-version: 1.2.0
 message: "If you use Kedro-Dagster in your work, please cite it as below."
-title: "Kedro-Dagster"
-abstract: "Kedro-Dagster makes it easy to deploy Kedro projects to Dagster"
+# Name and description in one field, because that is what a citation renders. A
+# reference list shows the title and nothing else, so a bare package name tells a
+# reader who has not met the project what it was called and not what it is. There
+# is deliberately no separate `abstract`: it duplicated this text, and the field a
+# citation actually prints is this one.
+title: "Kedro-Dagster: Deploy Kedro projects to Dagster"
 type: software
 authors:
   # Recorded as a single `name`, which the format treats as an entity rather than a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Kedro-Dagster
 
-Kedro-Dagster makes it easy to deploy Kedro projects to Dagster
+Deploy Kedro projects to Dagster
 
 Instructions for AI coding assistants working in this repository.
 

--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ This project is licensed under the terms of the [Apache-2.0 License](https://git
 
 If you use Kedro-Dagster in work you publish, please cite it:
 
-Guillaume Tauzin. Kedro-Dagster. https://github.com/stateful-y/kedro-dagster
+Guillaume Tauzin. Kedro-Dagster: Deploy Kedro projects to Dagster. https://github.com/stateful-y/kedro-dagster
 
 Or in BibTeX:
 
 ```bibtex
 @software{kedro_dagster,
   author  = "Guillaume Tauzin",
-  title   = "{Kedro-Dagster}",
+  title   = "{Kedro-Dagster: Deploy Kedro projects to Dagster}",
   url     = "https://github.com/stateful-y/kedro-dagster",
   license = "Apache-2.0"
 }

--- a/README.md
+++ b/README.md
@@ -153,6 +153,25 @@ For questions and discussions, you can also open a [discussion](https://github.c
 
 This project is licensed under the terms of the [Apache-2.0 License](https://github.com/stateful-y/kedro-dagster/blob/main/LICENSE).
 
+## How do I cite Kedro-Dagster?
+
+If you use Kedro-Dagster in work you publish, please cite it:
+
+Guillaume Tauzin. Kedro-Dagster. https://github.com/stateful-y/kedro-dagster
+
+Or in BibTeX:
+
+```bibtex
+@software{kedro_dagster,
+  author  = "Guillaume Tauzin",
+  title   = "{Kedro-Dagster}",
+  url     = "https://github.com/stateful-y/kedro-dagster",
+  license = "Apache-2.0"
+}
+```
+
+Reference managers can read [CITATION.cff](https://github.com/stateful-y/kedro-dagster/blob/main/CITATION.cff) directly. To cite a specific version, see the [citation page](https://kedro-dagster.readthedocs.io/en/latest/pages/reference/citation/).
+
 ## Acknowledgements
 
 This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in MLOps and data science & engineering. If you're interested in collaborating or learning more about our services, please visit our website.

--- a/docs/pages/reference/citation.md
+++ b/docs/pages/reference/citation.md
@@ -1,0 +1,49 @@
+---
+description: How to cite Kedro-Dagster, in plain text and in BibTeX.
+---
+
+# Citation
+
+If you use Kedro-Dagster in work you publish, please cite it.
+
+## Plain text
+
+Guillaume Tauzin. Kedro-Dagster. https://github.com/stateful-y/kedro-dagster
+
+## BibTeX
+
+```bibtex
+@software{kedro_dagster,
+  author  = "Guillaume Tauzin",
+  title   = "{Kedro-Dagster}",
+  url     = "https://github.com/stateful-y/kedro-dagster",
+  license = "Apache-2.0"
+}
+```
+
+The entry carries no `year` and no `version` on purpose, for the same reason the
+machine-readable file below carries no release date: either one is wrong as soon as
+the next version ships. If your citation style needs them, add the year and the
+version you actually used:
+
+```text
+  year    = "2026",
+  version = "1.2.3",
+```
+
+The version you used is the one `pip show kedro_dagster` reports.
+
+## Machine-readable metadata
+
+The repository root carries a
+[`CITATION.cff`](https://github.com/stateful-y/kedro-dagster/blob/main/CITATION.cff)
+file. It is the same citation in the Citation File Format, which is what GitHub's
+"Cite this repository" button, Zenodo, and most reference managers read. If your tool
+can import that file, prefer it over copying from this page: it cannot fall out of
+step with the repository.
+
+## There is no DOI
+
+No release of Kedro-Dagster has been deposited with a DOI-issuing archive, so
+there is no DOI to cite. Cite the repository URL above instead. If that changes, the
+`doi` field in `CITATION.cff` is where it will appear first.

--- a/docs/pages/reference/citation.md
+++ b/docs/pages/reference/citation.md
@@ -8,14 +8,14 @@ If you use Kedro-Dagster in work you publish, please cite it.
 
 ## Plain text
 
-Guillaume Tauzin. Kedro-Dagster. https://github.com/stateful-y/kedro-dagster
+Guillaume Tauzin. Kedro-Dagster: Deploy Kedro projects to Dagster. https://github.com/stateful-y/kedro-dagster
 
 ## BibTeX
 
 ```bibtex
 @software{kedro_dagster,
   author  = "Guillaume Tauzin",
-  title   = "{Kedro-Dagster}",
+  title   = "{Kedro-Dagster: Deploy Kedro projects to Dagster}",
   url     = "https://github.com/stateful-y/kedro-dagster",
   license = "Apache-2.0"
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -290,6 +290,7 @@ nav:
     - API: pages/reference/api.md
     - Datasets: pages/reference/datasets.md
     - Changelog: pages/reference/changelog.md
+    - Citation: pages/reference/citation.md
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "kedro_dagster"
 dynamic = ["version"]
-description = "Kedro-Dagster makes it easy to deploy Kedro projects to Dagster"
+description = "Deploy Kedro projects to Dagster"
 readme = "README.md"
 maintainers = [
     { name = "Guillaume Tauzin", email = "gtauzin@stateful-y.io" }


### PR DESCRIPTION
## Description

Template update, v0.42.0 to v0.43.0. Adds citation metadata so this project can be cited:

- **`CITATION.cff`** at the repo root. This is what GitHub's "Cite this repository" button, Zenodo and most reference managers read. Rendered from the answers this project already has.
- **A `## How do I cite ...?` section in `README.md`**, between License and Acknowledgements.
- **`docs/pages/reference/citation.md`**, listed in the Reference nav beside Changelog and API.

Two deliberate absences in `CITATION.cff`, both explained inline in the file: no `version` and no `date-released` (optional, the citation button works without them, and both would be wrong the day after the next release with nothing keeping them right), and the `doi:` line ships commented out because no release has been deposited with a DOI-issuing archive.

Also carries v0.42.0's comment-only rewording of `.github/workflows/renovate-automerge.yml` and the `update-from-template` classification entries for the two new files (both Tier 2, merge-required, because the commented `doi:` exists so this project can fill it in and a Tier 1 overwrite would delete it silently).

## Verification

- Conflicts checked three ways: `.rej` files, `U` states in `git status --porcelain`, and a conflict-marker grep. Findings and resolutions below.
- Nav counted **per section** before and after, and the leaf list compared with titles included. Per-section counts are the only check that catches the `mkdocs.yml` clobber that hit 7 of 7 repos on v0.26.0.
- `CITATION.cff` verified on disk and not gitignored (not via `git status`, which an unresolved `.gitignore` conflict can make lie), and its `title`, `repository-code` and `abstract` confirmed to carry this project's own values.
- `git diff --stat -- docs/assets` empty.
- The generated project's own hooks (`prek run --all-files`) run after staging, so the new files are actually seen.

## Note

`.github/skills/update-from-template/references/file-classification.md` is gitignored here, and copier wrote it to disk anyway, untracked. It is therefore not in this diff. The template's own note claims copier "skips ignored paths"; that is wrong and is being fixed upstream.

**Held for review. Do not merge without reading the nav diff.**

## What happened in this repo

**The full nav clobber fired.** copier replaced the curated nav with the template's pristine one: 27 leaves collapsed to 13, losing all 16 curated pages (both extra tutorials, seven how-tos including Troubleshooting, three explanation pages, and Configuration/CLI/Datasets from Reference), with the real nav left in a single `mkdocs.yml.rej`. This is the same failure that hit 7 of 7 repos on v0.26.0. Resolved by `git checkout HEAD -- mkdocs.yml` and hand-adding the one line the template actually changed, verified against a pristine-render diff of the version pair. Final `mkdocs.yml` diff is exactly one added line.

Nav is 27 -> 28 leaves, Reference 6 -> 7, no other section changed and no leaf lost.
